### PR TITLE
add structured logging capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ for msg := range consumer.Messages() {
 // received: hello world
 ```
 
+## Logging
+
+You can pass a pointer to a `zap.Logger` instance to each of the above described
+clients.
+
+```golang
+logger := func(c *kafka.Client) {
+  c.Logger, _ = zap.NewProduction()
+}
+
+client := kafka.NewClient(logger)
+```
+
 ## Messages
 
 A message is implemented as such:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,5 @@ package: github.com/blendle/go-streamprocessor
 import:
 - package: github.com/bsm/sarama-cluster
   version: ^2.1.8
+- package: go.uber.org/zap
+  version: ^1.4.1

--- a/streamclient/inmem/client.go
+++ b/streamclient/inmem/client.go
@@ -1,11 +1,16 @@
 package inmem
 
 import "github.com/blendle/go-streamprocessor/stream"
+import "go.uber.org/zap"
 
 // Client provides access to the streaming capabilities.
 type Client struct {
 	ConsumerTopic string
 	ProducerTopic string
+
+	// Logger is the configurable logger instance to log messages from this
+	// streamclient. If left undefined, a noop logger will be used.
+	Logger *zap.Logger
 
 	store *Store
 }
@@ -22,6 +27,10 @@ func NewClientWithStore(store *Store, options ...func(*Client)) stream.Client {
 
 	for _, option := range options {
 		option(client)
+	}
+
+	if client.Logger == nil {
+		client.Logger = zap.NewNop()
 	}
 
 	return client

--- a/streamclient/kafka/client.go
+++ b/streamclient/kafka/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/blendle/go-streamprocessor/stream"
 	cluster "github.com/bsm/sarama-cluster"
+	"go.uber.org/zap"
 )
 
 // Client provides access to the streaming capabilities.
@@ -22,6 +23,10 @@ type Client struct {
 
 	ProducerBrokers []string
 	ProducerTopics  []string
+
+	// Logger is the configurable logger instance to log messages from this
+	// streamclient. If left undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // NewClient returns a new kafka client.
@@ -47,6 +52,10 @@ func NewClient(options ...func(*Client)) stream.Client {
 
 	for _, option := range options {
 		option(c)
+	}
+
+	if c.Logger == nil {
+		c.Logger = zap.NewNop()
 	}
 
 	return c

--- a/streamclient/kafka/consumer.go
+++ b/streamclient/kafka/consumer.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"github.com/blendle/go-streamprocessor/stream"
 	cluster "github.com/bsm/sarama-cluster"
+	"go.uber.org/zap"
 )
 
 // NewConsumer returns a consumer that can iterate over messages on a stream.
@@ -12,6 +13,13 @@ func (c *Client) NewConsumer() stream.Consumer {
 		c.ConsumerGroup,
 		c.ConsumerTopics,
 		c.ClusterConfig,
+	)
+
+	c.Logger.Info(
+		"Using provided Kafka consumer configuration",
+		zap.Strings("brokers", c.ConsumerBrokers),
+		zap.String("group", c.ConsumerGroup),
+		zap.Strings("topics", c.ConsumerTopics),
 	)
 
 	if err != nil {
@@ -34,6 +42,18 @@ func (c *Client) NewConsumer() stream.Consumer {
 			}
 
 			consumer.messages <- &message
+		}
+	}()
+
+	go func() {
+		for err := range kafkaconsumer.Errors() {
+			c.Logger.Error("Kafka consumer received error.", zap.Error(err))
+		}
+	}()
+
+	go func() {
+		for note := range kafkaconsumer.Notifications() {
+			c.Logger.Info("Kafka consumer received notification.", zap.Any("notification", note))
 		}
 	}()
 

--- a/streamclient/kafka/producer.go
+++ b/streamclient/kafka/producer.go
@@ -1,16 +1,22 @@
 package kafka
 
 import (
-	"log"
 	"sync"
 
 	"github.com/Shopify/sarama"
 	"github.com/blendle/go-streamprocessor/stream"
+	"go.uber.org/zap"
 )
 
 // NewProducer returns a producer that produces messages on a Kafka stream.
 func (c *Client) NewProducer() stream.Producer {
 	var err error
+
+	c.Logger.Info(
+		"Using provided Kafka producer configuration",
+		zap.Strings("brokers", c.ProducerBrokers),
+		zap.Strings("topics", c.ProducerTopics),
+	)
 
 	ch := make(chan *stream.Message)
 	producer := &Producer{messages: ch}
@@ -42,7 +48,7 @@ func (c *Client) NewProducer() stream.Producer {
 
 	go func() {
 		for err := range producer.sp.Errors() {
-			log.Println(err)
+			c.Logger.Error("Kafa producer received error.", zap.Error(err))
 		}
 	}()
 

--- a/streamclient/standardstream/client.go
+++ b/streamclient/standardstream/client.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/blendle/go-streamprocessor/stream"
+	"go.uber.org/zap"
 )
 
 // Client provides access to the streaming capabilities.
@@ -16,6 +17,10 @@ type Client struct {
 	// ProducerFD is the file descriptor to produce messages to. If undefined, the
 	// `os.Stdout` descriptor will be used.
 	ProducerFD io.Writer
+
+	// Logger is the configurable logger instance to log messages from this
+	// streamclient. If left undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // NewClient returns a new standardstream client.
@@ -32,6 +37,10 @@ func NewClient(options ...func(*Client)) stream.Client {
 
 	if client.ProducerFD == nil {
 		client.ProducerFD = os.Stdout
+	}
+
+	if client.Logger == nil {
+		client.Logger = zap.NewNop()
 	}
 
 	return client


### PR DESCRIPTION
You can pass a pointer to a `zap.Logger` instance to the configured client.

```golang
logger := func(c *kafka.Client) {
  c.Logger, _ = zap.NewProduction()
}

client := kafka.NewClient(logger)
```
