### PR TITLE
correctly set offset for consumer Kafka messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,7 @@ producer.PartitionKey(func(msg *stream.Message) []byte {
 
 In the above example, we implement our own `getKey` function that takes `[]byte`
 as its input, and returns the key string as `[]byte`.
+
+## TODO
+
+- [ ] add unit tests for Kafka streamclient (e.g. missing offset commit).

--- a/streamclient/kafka/consumer.go
+++ b/streamclient/kafka/consumer.go
@@ -42,6 +42,11 @@ func (c *Client) NewConsumer() stream.Consumer {
 			}
 
 			consumer.messages <- &message
+
+			// FIXME: we're comitting too soon here, since the message goes into
+			// 				another channel, and could still fail or not be processed at
+			// 				that point.
+			kafkaconsumer.MarkOffset(msg, "")
 		}
 	}()
 


### PR DESCRIPTION
This still needs further tweaking, but at least there is an offset now.