### PR TITLE
add function to mark a message as “done”

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,25 @@ Next, loop over consumed messages, and produce new messages:
 
 ```golang
 for msg := range consumer.Messages() {
+
+  // Initialize a new message.
   message := &stream.Message{}
 
+  // Set the value of the message to the consumed message, prepended with
+  // "processed: ".
   message.Value = append([]byte("processed: "), msg.Value...)
 
+  // Send message to the configured producer.
   producer.Messages() <- message
+
+  // Mark the consumed message as "done". This lets the client know it should
+  // not retry this message if the application is restarted.
+  msg.Done()
 }
 ```
+
+Don't forget to mark the consumed message as "done", or you might end up
+processing the message multiple times.
 
 Now, run your example in your terminal:
 

--- a/stream/message.go
+++ b/stream/message.go
@@ -1,9 +1,38 @@
 package stream
 
-import "time"
+import (
+	"time"
+
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+)
 
 // Message send to or received from a stream.
 type Message struct {
-	Value     []byte
-	Timestamp time.Time
+	Value         []byte
+	Key           []byte
+	Timestamp     time.Time
+	kafkaMessage  *sarama.ConsumerMessage
+	kafkaConsumer *cluster.Consumer
+}
+
+// NewMessageFromKafka creates a new message with required Kafka metadata.
+func NewMessageFromKafka(msg *sarama.ConsumerMessage, c *cluster.Consumer) Message {
+	return Message{
+		Value:         msg.Value,
+		Key:           msg.Key,
+		Timestamp:     msg.Timestamp,
+		kafkaMessage:  msg,
+		kafkaConsumer: c,
+	}
+}
+
+// Done tells the consumer a message has been processed, and should not be send
+// again.
+func (m *Message) Done() {
+	if m.kafkaConsumer == nil || m.kafkaMessage == nil {
+		return
+	}
+
+	m.kafkaConsumer.MarkOffset(m.kafkaMessage, "")
 }

--- a/streamclient/inmem/consumer.go
+++ b/streamclient/inmem/consumer.go
@@ -22,8 +22,6 @@ func (c *Client) NewConsumer() stream.Consumer {
 
 // Consumer implements the stream.Consumer interface for standardstream.
 type Consumer struct {
-	Topic string
-
 	messages chan *stream.Message
 }
 

--- a/streamclient/kafka/consumer.go
+++ b/streamclient/kafka/consumer.go
@@ -36,17 +36,8 @@ func (c *Client) NewConsumer() stream.Consumer {
 		var message stream.Message
 
 		for msg := range kafkaconsumer.Messages() {
-			message = stream.Message{
-				Value:     msg.Value,
-				Timestamp: msg.Timestamp,
-			}
-
+			message = stream.NewMessageFromKafka(msg, kafkaconsumer)
 			consumer.messages <- &message
-
-			// FIXME: we're comitting too soon here, since the message goes into
-			// 				another channel, and could still fail or not be processed at
-			// 				that point.
-			kafkaconsumer.MarkOffset(msg, "")
 		}
 	}()
 


### PR DESCRIPTION
What this means for the message can differ per client, but in the case of Kafka, this means the consumer offset is committed to the topic.

Still not too happy with the design of this, but sticking with it for now, until a better solution presents itself.