### PR TITLE
Fix benchmark tests using wrong topic names

### DIFF
--- a/streamclient/inmem/consumer_test.go
+++ b/streamclient/inmem/consumer_test.go
@@ -67,7 +67,11 @@ func BenchmarkConsumer_Messages1000(b *testing.B) {
 		topic.NewMessage([]byte(fmt.Sprintf(content, n)), nil)
 	}
 
-	c := inmem.NewClientWithStore(store)
+	ct := func(c *inmem.Client) {
+		c.ConsumerTopic = "test-topic"
+	}
+
+	c := inmem.NewClientWithStore(store, ct)
 
 	b.ResetTimer()
 

--- a/streamclient/inmem/producer_test.go
+++ b/streamclient/inmem/producer_test.go
@@ -46,9 +46,13 @@ func TestProducer_Messages(t *testing.T) {
 func BenchmarkProducer_Messages1000(b *testing.B) {
 	content := `{"number":%d}`
 
+	pt := func(c *inmem.Client) {
+		c.ProducerTopic = "test-topic"
+	}
+
 	store := inmem.NewStore()
 	topic := store.NewTopic("test-topic")
-	client := inmem.NewClientWithStore(store)
+	client := inmem.NewClientWithStore(store, pt)
 	producer := client.NewProducer()
 
 	for n := 1; n < b.N; n++ {


### PR DESCRIPTION
Overlooked due to optional arguments (still debating when to use this type of options and when not)