### PR TITLE
only auto populate Kafka config when needed

### DIFF
--- a/streamclient/kafka/client.go
+++ b/streamclient/kafka/client.go
@@ -77,33 +77,37 @@ func (c *Client) autoPopulateKafkaConfig() {
 	var broker, group, topic string
 	var err error
 
-	if u := os.Getenv("KAFKA_CONSUMER_URL"); u != "" {
-		broker, group, topic, err = ParseKafkaURL(u)
-		if err != nil {
-			return
+	if len(c.ConsumerBrokers) == 0 {
+		if u := os.Getenv("KAFKA_CONSUMER_URL"); u != "" {
+			broker, group, topic, err = ParseKafkaURL(u)
+			if err != nil {
+				return
+			}
+		} else {
+			broker = "localhost:9092"
+			group = "test-group"
+			topic = "consumer-topic"
 		}
-	} else {
-		broker = "localhost:9092"
-		group = "test-group"
-		topic = "consumer-topic"
+
+		c.ConsumerBrokers = []string{broker}
+		c.ConsumerTopics = []string{topic}
+		c.ConsumerGroup = group
 	}
 
-	c.ConsumerBrokers = []string{broker}
-	c.ConsumerTopics = []string{topic}
-	c.ConsumerGroup = group
-
-	if u := os.Getenv("KAFKA_PRODUCER_URL"); u != "" {
-		broker, _, topic, err = ParseKafkaURL(u)
-		if err != nil {
-			return
+	if len(c.ProducerBrokers) == 0 {
+		if u := os.Getenv("KAFKA_PRODUCER_URL"); u != "" {
+			broker, _, topic, err = ParseKafkaURL(u)
+			if err != nil {
+				return
+			}
+		} else {
+			broker = "localhost:9092"
+			topic = "producer-topic"
 		}
-	} else {
-		broker = "localhost:9092"
-		topic = "producer-topic"
-	}
 
-	c.ProducerBrokers = []string{broker}
-	c.ProducerTopics = []string{topic}
+		c.ProducerBrokers = []string{broker}
+		c.ProducerTopics = []string{topic}
+	}
 }
 
 // ParseKafkaURL parses a Kafka URL and returns the relevant components.


### PR DESCRIPTION
Since https://github.com/blendle/go-streamprocessor/pull/14, you can more easily initialise only a Kafka consumer or producer.

This piece of code still expects both to be configured, or it'll use the default values. This was causing unintended side-effects.

This code still needs a good rethinking/refactor, and also still needs some tests, but for now, this solves the problem.