### PR TITLE
Improve stdin detection code

### DIFF
--- a/streamclient/streamclient.go
+++ b/streamclient/streamclient.go
@@ -71,7 +71,7 @@ func NewConsumer(options ...func(sc *standardstream.Client, kc *kafka.Client)) (
 		return consumer, err
 	}
 
-	if stat.Size() > 0 {
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		c := standardstream.NewClient(scopt)
 		consumer = c.NewConsumer()
 	} else {


### PR DESCRIPTION
The previous version worked locally, but not when running:

    echo “hello world” | docker run -i streamprocessor

This change makes both scenarios work as expected.