### PR TITLE
correctly close consumer and producer on kill signal

### DIFF
--- a/streamclient/kafka/consumer.go
+++ b/streamclient/kafka/consumer.go
@@ -121,6 +121,6 @@ func (c *Consumer) listenForInterrupts(l *zap.Logger) {
 	l.Info("Got interrupt signal, cleaning up.", zap.String("signal", s.String()))
 
 	if err := c.Close(); err != nil {
-		l.Error("Could close kafka consumer properly", zap.Error(err))
+		l.Error("Error while closing consumer.", zap.Error(err))
 	}
 }

--- a/streamclient/kafka/producer.go
+++ b/streamclient/kafka/producer.go
@@ -126,6 +126,6 @@ func (p *Producer) listenForInterrupts(l *zap.Logger) {
 	l.Info("Got interrupt signal, cleaning up.", zap.String("signal", s.String()))
 
 	if err := p.Close(); err != nil {
-		l.Error("Could close kafka consumer properly", zap.Error(err))
+		l.Error("Error while closing producer.", zap.Error(err))
 	}
 }


### PR DESCRIPTION
This allows us to start using stream processors on preemptible machines (and is good practice in general).

Kindly borrowed from https://github.com/blendle/bundle-processors/pull/31