### PR TITLE
support setting message key directly

### DIFF
--- a/streamclient/inmem/producer.go
+++ b/streamclient/inmem/producer.go
@@ -19,7 +19,11 @@ func (c *Client) NewProducer() stream.Producer {
 	go func() {
 		defer producer.wg.Done()
 		for msg := range ch {
-			key := producer.keyFunc(msg)
+			key := msg.Key
+
+			if producer.keyFunc != nil {
+				key = producer.keyFunc(msg)
+			}
 
 			c.store.NewTopic(c.ProducerTopic).NewMessage(msg.Value, key)
 		}

--- a/streamclient/kafka/producer.go
+++ b/streamclient/kafka/producer.go
@@ -37,10 +37,14 @@ func (c *Client) NewProducer() stream.Producer {
 			value := make([]byte, len(msg.Value))
 			copy(value, msg.Value)
 
+			key := make([]byte, len(msg.Key))
+			copy(key, msg.Key)
+
 			message := sarama.ProducerMessage{
 				Timestamp: msg.Timestamp,
 				Topic:     c.ProducerTopics[0],
 				Value:     sarama.ByteEncoder(value),
+				Key:       sarama.ByteEncoder(key),
 			}
 
 			if producer.keyFunc != nil {


### PR DESCRIPTION
I'm not sure anymore why I added the `PartitionKey` logic in the first place, instead of setting the key directly on the message.

This caught me off-guard in a separate stream-processor where I'm looping over a stream of data outside of this library, and have a method there that determines the key to be used. This means I can't set the key out-of-bounds using the `PartitionKey` function.

I had set `message.Key`, but it was never used, and thus didn't work as I expected.

Also: this needs tests, _lots_ of tests, but first it needs to be shipped so I can finish the Mixpanel import, then we can start adding tests if/when we start to use this library more broadly at Blendle.