### PR TITLE
Add capability to dynamically define producer topic per message

### DIFF
--- a/stream/message.go
+++ b/stream/message.go
@@ -11,6 +11,7 @@ import (
 type Message struct {
 	Value         []byte
 	Key           []byte
+	Topic         string
 	Timestamp     time.Time
 	kafkaMessage  *sarama.ConsumerMessage
 	kafkaConsumer *cluster.Consumer

--- a/streamclient/kafka/client.go
+++ b/streamclient/kafka/client.go
@@ -113,6 +113,14 @@ func (c *Client) autoPopulateKafkaConfig() {
 	}
 }
 
+func (c *Client) topicName(msg *stream.Message) string {
+	if msg.Topic != "" {
+		return msg.Topic
+	}
+
+	return c.ProducerTopics[0]
+}
+
 // ParseKafkaURL parses a Kafka URL and returns the relevant components.
 func ParseKafkaURL(uri string) (string, string, string, error) {
 	u, err := url.Parse(uri)

--- a/streamclient/kafka/producer.go
+++ b/streamclient/kafka/producer.go
@@ -42,7 +42,7 @@ func (c *Client) NewProducer() stream.Producer {
 
 			message := sarama.ProducerMessage{
 				Timestamp: msg.Timestamp,
-				Topic:     c.ProducerTopics[0],
+				Topic:     c.topicName(msg),
 				Value:     sarama.ByteEncoder(value),
 				Key:       sarama.ByteEncoder(key),
 			}


### PR DESCRIPTION
You can optionally define the topic for the produced messages dynamically on a
message:

```golang
msg := &stream.Message{
  Value: []byte("hello world"),
  Topic: "my-dynamic-topic",
}

producer.Messages() <- msg
```

paired on this with @jurre 🎉 