### PR TITLE
Fix a nil pointer error

### DIFF
--- a/streamclient/streamclient.go
+++ b/streamclient/streamclient.go
@@ -3,10 +3,12 @@ package streamclient
 import (
 	"os"
 
+	"github.com/Shopify/sarama"
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/inmem"
 	"github.com/blendle/go-streamprocessor/streamclient/kafka"
 	"github.com/blendle/go-streamprocessor/streamclient/standardstream"
+	cluster "github.com/bsm/sarama-cluster"
 )
 
 // Client is the overarching configuration for all stream clients.
@@ -41,6 +43,8 @@ func NewConsumer(options ...func(sc *standardstream.Client, kc *kafka.Client)) (
 
 	sc := &standardstream.Client{}
 	kc := &kafka.Client{}
+	kc.ConsumerConfig = cluster.NewConfig()
+	kc.ProducerConfig = sarama.NewConfig()
 
 	for _, option := range options {
 		option(sc, kc)
@@ -93,6 +97,8 @@ func NewProducer(options ...func(sc *standardstream.Client, kc *kafka.Client)) (
 
 	sc := &standardstream.Client{}
 	kc := &kafka.Client{}
+	kc.ConsumerConfig = cluster.NewConfig()
+	kc.ProducerConfig = sarama.NewConfig()
 
 	for _, option := range options {
 		option(sc, kc)

--- a/streamclient/streamclient_test.go
+++ b/streamclient/streamclient_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Shopify/sarama"
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafka"
@@ -118,8 +119,9 @@ func TestNewConsumerAndProducer_StandardstreamConsumerAndKafkaProducer(t *testin
 
 	// Set the streamclient file descriptor to a temporary file, simulating
 	// received data in the Stdin fd.
-	options := func(s *standardstream.Client, _ *kafka.Client) {
+	options := func(s *standardstream.Client, kc *kafka.Client) {
 		s.ConsumerFD = f
+		kc.ConsumerConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
 	}
 
 	c, p, err := streamclient.NewConsumerAndProducer(options)


### PR DESCRIPTION
We were trying to use the streamclient.NewConsumerAndProducer helper and in the optoins function set the `kc.ConsumerConfig.Consumer.Offsets.Initial = sarama.OffsetNewest`, which failed because in this flow the ConsumerConfig was never initialised and still _nil_.

This change initialises the both the ConsumerConfig and the ProducerConfig on the kafka.Client.