### PR TITLE
Add initial stream package

### DIFF
--- a/stream/client.go
+++ b/stream/client.go
@@ -1,0 +1,7 @@
+package stream
+
+// Client interface to be implemented by different stream clients.
+type Client interface {
+	NewConsumer(options ...func(interface{})) (Consumer, error)
+	NewProducer(options ...func(interface{})) (Producer, error)
+}

--- a/stream/client_test.go
+++ b/stream/client_test.go
@@ -1,0 +1,22 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/stream"
+)
+
+type FakeClient struct {
+}
+
+func (fc *FakeClient) NewConsumer(options ...func(interface{})) (stream.Consumer, error) {
+	return nil, nil
+}
+
+func (fc *FakeClient) NewProducer(options ...func(interface{})) (stream.Producer, error) {
+	return nil, nil
+}
+
+func TestClient(t *testing.T) {
+	var _ stream.Client = (*FakeClient)(nil)
+}

--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -1,0 +1,7 @@
+package stream
+
+// Consumer interface to be implemented by different stream clients.
+type Consumer interface {
+	Messages() <-chan *Message
+	Close() error
+}

--- a/stream/consumer_test.go
+++ b/stream/consumer_test.go
@@ -1,0 +1,23 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/stream"
+)
+
+type FakeConsumer struct {
+	messages chan *stream.Message
+}
+
+func (fc *FakeConsumer) Messages() <-chan *stream.Message {
+	return fc.messages
+}
+
+func (fc *FakeConsumer) Close() error {
+	return nil
+}
+
+func TestConsumer(t *testing.T) {
+	var _ stream.Consumer = (*FakeConsumer)(nil)
+}

--- a/stream/message.go
+++ b/stream/message.go
@@ -1,0 +1,11 @@
+package stream
+
+import "time"
+
+// Message represents a single object received or sent to a stream, using one of
+// the configured stream consumers or producers.
+type Message struct {
+	Value     []byte
+	Key       []byte
+	Timestamp time.Time
+}

--- a/stream/message_test.go
+++ b/stream/message_test.go
@@ -1,0 +1,16 @@
+package stream_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blendle/go-streamprocessor/stream"
+)
+
+func TestMessage(t *testing.T) {
+	_ = stream.Message{
+		Value:     []byte("testValue"),
+		Key:       []byte("testKey"),
+		Timestamp: time.Now(),
+	}
+}

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -1,0 +1,7 @@
+package stream
+
+// Producer interface to be implemented by different stream clients.
+type Producer interface {
+	Messages() chan<- *Message
+	Close() error
+}

--- a/stream/producer_test.go
+++ b/stream/producer_test.go
@@ -1,0 +1,23 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/stream"
+)
+
+type FakeProducer struct {
+	messages chan<- *stream.Message
+}
+
+func (fp *FakeProducer) Messages() chan<- *stream.Message {
+	return fp.messages
+}
+
+func (fp *FakeProducer) Close() error {
+	return nil
+}
+
+func TestProducer(t *testing.T) {
+	var _ stream.Producer = (*FakeProducer)(nil)
+}


### PR DESCRIPTION
This is a work-in-progress. I'm going to create several PRs, all based off of each other. I'll be working on this on-and-off again in my evening hours as a fun project, but feel free to block some time to review the PRs, as I think it's important we do this right, before we start using this in many more processors in the future.

---

This adds the initial interfaces, mostly as they where before, with some slight changes. Most significantly, the consumers and producers now take their own (optional) configuration values, instead of inheriting them from the client.

I've also removed some of the client implementation-specific values from the `Message` struct. We'll tackle that later.