### PR TITLE
Add initial streamconfig package

### DIFF
--- a/stream/client.go
+++ b/stream/client.go
@@ -1,7 +1,9 @@
 package stream
 
+import "github.com/blendle/go-streamprocessor/streamconfig"
+
 // Client interface to be implemented by different stream clients.
 type Client interface {
-	NewConsumer(options ...func(interface{})) (Consumer, error)
-	NewProducer(options ...func(interface{})) (Producer, error)
+	NewConsumer(options ...func(*streamconfig.Consumer)) (Consumer, error)
+	NewProducer(options ...func(*streamconfig.Producer)) (Producer, error)
 }

--- a/stream/client.go
+++ b/stream/client.go
@@ -6,4 +6,5 @@ import "github.com/blendle/go-streamprocessor/streamconfig"
 type Client interface {
 	NewConsumer(options ...func(*streamconfig.Consumer)) (Consumer, error)
 	NewProducer(options ...func(*streamconfig.Producer)) (Producer, error)
+	Config() streamconfig.Client
 }

--- a/stream/client_test.go
+++ b/stream/client_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
 )
 
 type FakeClient struct {
 }
 
-func (fc *FakeClient) NewConsumer(options ...func(interface{})) (stream.Consumer, error) {
+func (fc *FakeClient) NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
 	return nil, nil
 }
 
-func (fc *FakeClient) NewProducer(options ...func(interface{})) (stream.Producer, error) {
+func (fc *FakeClient) NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
 	return nil, nil
 }
 

--- a/stream/client_test.go
+++ b/stream/client_test.go
@@ -18,6 +18,10 @@ func (fc *FakeClient) NewProducer(options ...func(*streamconfig.Producer)) (stre
 	return nil, nil
 }
 
+func (fc *FakeClient) Config() streamconfig.Client {
+	return streamconfig.Client{}
+}
+
 func TestClient(t *testing.T) {
 	var _ stream.Client = (*FakeClient)(nil)
 }

--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -1,7 +1,10 @@
 package stream
 
+import "github.com/blendle/go-streamprocessor/streamconfig"
+
 // Consumer interface to be implemented by different stream clients.
 type Consumer interface {
 	Messages() <-chan *Message
 	Close() error
+	Config() streamconfig.Consumer
 }

--- a/stream/consumer_test.go
+++ b/stream/consumer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
 )
 
 type FakeConsumer struct {
@@ -16,6 +17,10 @@ func (fc *FakeConsumer) Messages() <-chan *stream.Message {
 
 func (fc *FakeConsumer) Close() error {
 	return nil
+}
+
+func (fc *FakeConsumer) Config() streamconfig.Consumer {
+	return streamconfig.Consumer{}
 }
 
 func TestConsumer(t *testing.T) {

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -1,7 +1,10 @@
 package stream
 
+import "github.com/blendle/go-streamprocessor/streamconfig"
+
 // Producer interface to be implemented by different stream clients.
 type Producer interface {
 	Messages() chan<- *Message
 	Close() error
+	Config() streamconfig.Producer
 }

--- a/stream/producer_test.go
+++ b/stream/producer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
 )
 
 type FakeProducer struct {
@@ -16,6 +17,10 @@ func (fp *FakeProducer) Messages() chan<- *stream.Message {
 
 func (fp *FakeProducer) Close() error {
 	return nil
+}
+
+func (fp *FakeProducer) Config() streamconfig.Producer {
+	return streamconfig.Producer{}
 }
 
 func TestProducer(t *testing.T) {

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -13,10 +13,10 @@ import (
 // client only has to support a single implementation of the interface, then all
 // other configuration values can be ignored.
 type Client struct {
-	Inmem          *inmemconfig.Client
-	Kafka          *kafkaconfig.Client
-	Pubsub         *pubsubconfig.Client
-	Standardstream *standardstreamconfig.Client
+	Inmem          inmemconfig.Client
+	Kafka          kafkaconfig.Client
+	Pubsub         pubsubconfig.Client
+	Standardstream standardstreamconfig.Client
 }
 
 // Consumer works the same as `streamconfig.Client`, except that it contains the
@@ -25,17 +25,17 @@ type Client struct {
 // consumer can have its own behavior, dictated by the provided
 // `streamconfig.Consumer`.
 type Consumer struct {
-	Inmem          *inmemconfig.Consumer
-	Kafka          *kafkaconfig.Consumer
-	Pubsub         *pubsubconfig.Consumer
-	Standardstream *standardstreamconfig.Consumer
+	Inmem          inmemconfig.Consumer
+	Kafka          kafkaconfig.Consumer
+	Pubsub         pubsubconfig.Consumer
+	Standardstream standardstreamconfig.Consumer
 }
 
 // Producer works the same as `streamconfig.Consumer`, except that it dictates
 // the behaviour of a producer, instead of a consumer.
 type Producer struct {
-	Inmem          *inmemconfig.Producer
-	Kafka          *kafkaconfig.Producer
-	Pubsub         *pubsubconfig.Producer
-	Standardstream *standardstreamconfig.Producer
+	Inmem          inmemconfig.Producer
+	Kafka          kafkaconfig.Producer
+	Pubsub         pubsubconfig.Producer
+	Standardstream standardstreamconfig.Producer
 }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -1,0 +1,41 @@
+package streamconfig
+
+import (
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+// Client contains the configuration for all the different clients that
+// implement the stream.Client interface. When a client is instantiated, these
+// options can be passed into the new client to determine its behavior. If the
+// client only has to support a single implementation of the interface, then all
+// other configuration values can be ignored.
+type Client struct {
+	Inmem          *inmemconfig.Client
+	Kafka          *kafkaconfig.Client
+	Pubsub         *pubsubconfig.Client
+	Standardstream *standardstreamconfig.Client
+}
+
+// Consumer works the same as `streamconfig.Client`, except that it contains the
+// configuration for all the consumers instantiated from the already
+// instantiated client. Each client supports multiple consumers, and each
+// consumer can have its own behavior, dictated by the provided
+// `streamconfig.Consumer`.
+type Consumer struct {
+	Inmem          *inmemconfig.Consumer
+	Kafka          *kafkaconfig.Consumer
+	Pubsub         *pubsubconfig.Consumer
+	Standardstream *standardstreamconfig.Consumer
+}
+
+// Producer works the same as `streamconfig.Consumer`, except that it dictates
+// the behaviour of a producer, instead of a consumer.
+type Producer struct {
+	Inmem          *inmemconfig.Producer
+	Kafka          *kafkaconfig.Producer
+	Pubsub         *pubsubconfig.Producer
+	Standardstream *standardstreamconfig.Producer
+}

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -1,0 +1,19 @@
+package streamconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+func TestClient(t *testing.T) {
+	_ = streamconfig.Client{}
+}
+
+func TestConsumer(t *testing.T) {
+	_ = streamconfig.Consumer{}
+}
+
+func TestProducer(t *testing.T) {
+	_ = streamconfig.Producer{}
+}

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -30,12 +30,12 @@ func NewClient(options ...func(*Client)) (Client, error) {
 // NewConsumer returns a new Consumer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
+func NewConsumer(c Client, options ...func(*Consumer)) (Consumer, error) {
 	config := &Consumer{
-		Inmem:          inmemconfig.ConsumerDefaults,
-		Kafka:          kafkaconfig.ConsumerDefaults,
-		Pubsub:         pubsubconfig.ConsumerDefaults,
-		Standardstream: standardstreamconfig.ConsumerDefaults,
+		Inmem:          inmemconfig.ConsumerDefaults(c.Inmem),
+		Kafka:          kafkaconfig.ConsumerDefaults(c.Kafka),
+		Pubsub:         pubsubconfig.ConsumerDefaults(c.Pubsub),
+		Standardstream: standardstreamconfig.ConsumerDefaults(c.Standardstream),
 	}
 
 	for _, option := range options {
@@ -50,12 +50,12 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 // NewProducer returns a new Producer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewProducer(options ...func(*Producer)) (Producer, error) {
+func NewProducer(c Client, options ...func(*Producer)) (Producer, error) {
 	config := &Producer{
-		Inmem:          inmemconfig.ProducerDefaults,
-		Kafka:          kafkaconfig.ProducerDefaults,
-		Pubsub:         pubsubconfig.ProducerDefaults,
-		Standardstream: standardstreamconfig.ProducerDefaults,
+		Inmem:          inmemconfig.ProducerDefaults(c.Inmem),
+		Kafka:          kafkaconfig.ProducerDefaults(c.Kafka),
+		Pubsub:         pubsubconfig.ProducerDefaults(c.Pubsub),
+		Standardstream: standardstreamconfig.ProducerDefaults(c.Standardstream),
 	}
 
 	for _, option := range options {

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -12,10 +12,10 @@ import (
 // validation, an error is returned as the second argument.
 func NewClient(options ...func(*Client)) (Client, error) {
 	config := &Client{
-		Inmem:          inmemconfig.ClientDefaults,
-		Kafka:          kafkaconfig.ClientDefaults,
-		Pubsub:         pubsubconfig.ClientDefaults,
-		Standardstream: standardstreamconfig.ClientDefaults,
+		Inmem:          inmemconfig.ClientDefaults(),
+		Kafka:          kafkaconfig.ClientDefaults(),
+		Pubsub:         pubsubconfig.ClientDefaults(),
+		Standardstream: standardstreamconfig.ClientDefaults(),
 	}
 
 	for _, option := range options {

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -10,53 +10,59 @@ import (
 // NewClient returns a new Client configuration struct, containing the values
 // passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewClient(options ...func(*Client)) (*Client, error) {
+func NewClient(options ...func(*Client)) (Client, error) {
 	config := &Client{
-		Inmem:          &inmemconfig.ClientDefaults,
-		Kafka:          &kafkaconfig.ClientDefaults,
-		Pubsub:         &pubsubconfig.ClientDefaults,
-		Standardstream: &standardstreamconfig.ClientDefaults,
+		Inmem:          inmemconfig.ClientDefaults,
+		Kafka:          kafkaconfig.ClientDefaults,
+		Pubsub:         pubsubconfig.ClientDefaults,
+		Standardstream: standardstreamconfig.ClientDefaults,
 	}
 
 	for _, option := range options {
 		option(config)
 	}
 
-	return config, nil
+	// We pass the config by-value, to prevent any race-condition where the
+	// original config struct is modified after the fact.
+	return *config, nil
 }
 
 // NewConsumer returns a new Consumer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewConsumer(options ...func(*Consumer)) (*Consumer, error) {
+func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 	config := &Consumer{
-		Inmem:          &inmemconfig.ConsumerDefaults,
-		Kafka:          &kafkaconfig.ConsumerDefaults,
-		Pubsub:         &pubsubconfig.ConsumerDefaults,
-		Standardstream: &standardstreamconfig.ConsumerDefaults,
+		Inmem:          inmemconfig.ConsumerDefaults,
+		Kafka:          kafkaconfig.ConsumerDefaults,
+		Pubsub:         pubsubconfig.ConsumerDefaults,
+		Standardstream: standardstreamconfig.ConsumerDefaults,
 	}
 
 	for _, option := range options {
 		option(config)
 	}
 
-	return config, nil
+	// We pass the config by-value, to prevent any race-condition where the
+	// original config struct is modified after the fact.
+	return *config, nil
 }
 
 // NewProducer returns a new Producer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewProducer(options ...func(*Producer)) (*Producer, error) {
+func NewProducer(options ...func(*Producer)) (Producer, error) {
 	config := &Producer{
-		Inmem:          &inmemconfig.ProducerDefaults,
-		Kafka:          &kafkaconfig.ProducerDefaults,
-		Pubsub:         &pubsubconfig.ProducerDefaults,
-		Standardstream: &standardstreamconfig.ProducerDefaults,
+		Inmem:          inmemconfig.ProducerDefaults,
+		Kafka:          kafkaconfig.ProducerDefaults,
+		Pubsub:         pubsubconfig.ProducerDefaults,
+		Standardstream: standardstreamconfig.ProducerDefaults,
 	}
 
 	for _, option := range options {
 		option(config)
 	}
 
-	return config, nil
+	// We pass the config by-value, to prevent any race-condition where the
+	// original config struct is modified after the fact.
+	return *config, nil
 }

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -12,10 +12,10 @@ import (
 // validation, an error is returned as the second argument.
 func NewClient(options ...func(*Client)) (*Client, error) {
 	config := &Client{
-		Inmem:          &inmemconfig.Client{},
-		Kafka:          &kafkaconfig.Client{},
-		Pubsub:         &pubsubconfig.Client{},
-		Standardstream: &standardstreamconfig.Client{},
+		Inmem:          &inmemconfig.ClientDefaults,
+		Kafka:          &kafkaconfig.ClientDefaults,
+		Pubsub:         &pubsubconfig.ClientDefaults,
+		Standardstream: &standardstreamconfig.ClientDefaults,
 	}
 
 	for _, option := range options {
@@ -30,10 +30,10 @@ func NewClient(options ...func(*Client)) (*Client, error) {
 // validation, an error is returned as the second argument.
 func NewConsumer(options ...func(*Consumer)) (*Consumer, error) {
 	config := &Consumer{
-		Inmem:          &inmemconfig.Consumer{},
-		Kafka:          &kafkaconfig.Consumer{},
-		Pubsub:         &pubsubconfig.Consumer{},
-		Standardstream: &standardstreamconfig.Consumer{},
+		Inmem:          &inmemconfig.ConsumerDefaults,
+		Kafka:          &kafkaconfig.ConsumerDefaults,
+		Pubsub:         &pubsubconfig.ConsumerDefaults,
+		Standardstream: &standardstreamconfig.ConsumerDefaults,
 	}
 
 	for _, option := range options {
@@ -48,10 +48,10 @@ func NewConsumer(options ...func(*Consumer)) (*Consumer, error) {
 // validation, an error is returned as the second argument.
 func NewProducer(options ...func(*Producer)) (*Producer, error) {
 	config := &Producer{
-		Inmem:          &inmemconfig.Producer{},
-		Kafka:          &kafkaconfig.Producer{},
-		Pubsub:         &pubsubconfig.Producer{},
-		Standardstream: &standardstreamconfig.Producer{},
+		Inmem:          &inmemconfig.ProducerDefaults,
+		Kafka:          &kafkaconfig.ProducerDefaults,
+		Pubsub:         &pubsubconfig.ProducerDefaults,
+		Standardstream: &standardstreamconfig.ProducerDefaults,
 	}
 
 	for _, option := range options {

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -1,0 +1,62 @@
+package streamconfig
+
+import (
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+// NewClient returns a new Client configuration struct, containing the values
+// passed into the function. If any error occurs during configuration
+// validation, an error is returned as the second argument.
+func NewClient(options ...func(*Client)) (*Client, error) {
+	config := &Client{
+		Inmem:          &inmemconfig.Client{},
+		Kafka:          &kafkaconfig.Client{},
+		Pubsub:         &pubsubconfig.Client{},
+		Standardstream: &standardstreamconfig.Client{},
+	}
+
+	for _, option := range options {
+		option(config)
+	}
+
+	return config, nil
+}
+
+// NewConsumer returns a new Consumer configuration struct, containing the
+// values passed into the function. If any error occurs during configuration
+// validation, an error is returned as the second argument.
+func NewConsumer(options ...func(*Consumer)) (*Consumer, error) {
+	config := &Consumer{
+		Inmem:          &inmemconfig.Consumer{},
+		Kafka:          &kafkaconfig.Consumer{},
+		Pubsub:         &pubsubconfig.Consumer{},
+		Standardstream: &standardstreamconfig.Consumer{},
+	}
+
+	for _, option := range options {
+		option(config)
+	}
+
+	return config, nil
+}
+
+// NewProducer returns a new Producer configuration struct, containing the
+// values passed into the function. If any error occurs during configuration
+// validation, an error is returned as the second argument.
+func NewProducer(options ...func(*Producer)) (*Producer, error) {
+	config := &Producer{
+		Inmem:          &inmemconfig.Producer{},
+		Kafka:          &kafkaconfig.Producer{},
+		Pubsub:         &pubsubconfig.Producer{},
+		Standardstream: &standardstreamconfig.Producer{},
+	}
+
+	for _, option := range options {
+		option(config)
+	}
+
+	return config, nil
+}

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -1,0 +1,89 @@
+package streamconfig_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+func TestNewClient(t *testing.T) {
+	config, err := streamconfig.NewClient()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		expected string
+		config   interface{}
+	}{
+		{"*streamconfig.Client", config},
+		{"*inmemconfig.Client", config.Inmem},
+		{"*kafkaconfig.Client", config.Kafka},
+		{"*pubsubconfig.Client", config.Pubsub},
+		{"*standardstreamconfig.Client", config.Standardstream},
+	}
+
+	for _, tt := range tests {
+		expected := tt.expected
+		actual := reflect.TypeOf(tt.config).String()
+
+		if actual != expected {
+			t.Errorf("Expected %v to equal %v", actual, expected)
+		}
+	}
+}
+
+func TestNewConsumer(t *testing.T) {
+	config, err := streamconfig.NewConsumer()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		expected string
+		config   interface{}
+	}{
+		{"*streamconfig.Consumer", config},
+		{"*inmemconfig.Consumer", config.Inmem},
+		{"*kafkaconfig.Consumer", config.Kafka},
+		{"*pubsubconfig.Consumer", config.Pubsub},
+		{"*standardstreamconfig.Consumer", config.Standardstream},
+	}
+
+	for _, tt := range tests {
+		expected := tt.expected
+		actual := reflect.TypeOf(tt.config).String()
+
+		if actual != expected {
+			t.Errorf("Expected %v to equal %v", actual, expected)
+		}
+	}
+}
+
+func TestNewProducer(t *testing.T) {
+	config, err := streamconfig.NewProducer()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		expected string
+		config   interface{}
+	}{
+		{"*streamconfig.Producer", config},
+		{"*inmemconfig.Producer", config.Inmem},
+		{"*kafkaconfig.Producer", config.Kafka},
+		{"*pubsubconfig.Producer", config.Pubsub},
+		{"*standardstreamconfig.Producer", config.Standardstream},
+	}
+
+	for _, tt := range tests {
+		expected := tt.expected
+		actual := reflect.TypeOf(tt.config).String()
+
+		if actual != expected {
+			t.Errorf("Expected %v to equal %v", actual, expected)
+		}
+	}
+}

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -35,7 +35,12 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewConsumer(t *testing.T) {
-	config, err := streamconfig.NewConsumer()
+	cc, err := streamconfig.NewClient()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	config, err := streamconfig.NewConsumer(cc)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -62,7 +67,12 @@ func TestNewConsumer(t *testing.T) {
 }
 
 func TestNewProducer(t *testing.T) {
-	config, err := streamconfig.NewProducer()
+	cc, err := streamconfig.NewClient()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	config, err := streamconfig.NewProducer(cc)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -17,11 +17,11 @@ func TestNewClient(t *testing.T) {
 		expected string
 		config   interface{}
 	}{
-		{"*streamconfig.Client", config},
-		{"*inmemconfig.Client", config.Inmem},
-		{"*kafkaconfig.Client", config.Kafka},
-		{"*pubsubconfig.Client", config.Pubsub},
-		{"*standardstreamconfig.Client", config.Standardstream},
+		{"streamconfig.Client", config},
+		{"inmemconfig.Client", config.Inmem},
+		{"kafkaconfig.Client", config.Kafka},
+		{"pubsubconfig.Client", config.Pubsub},
+		{"standardstreamconfig.Client", config.Standardstream},
 	}
 
 	for _, tt := range tests {
@@ -44,11 +44,11 @@ func TestNewConsumer(t *testing.T) {
 		expected string
 		config   interface{}
 	}{
-		{"*streamconfig.Consumer", config},
-		{"*inmemconfig.Consumer", config.Inmem},
-		{"*kafkaconfig.Consumer", config.Kafka},
-		{"*pubsubconfig.Consumer", config.Pubsub},
-		{"*standardstreamconfig.Consumer", config.Standardstream},
+		{"streamconfig.Consumer", config},
+		{"inmemconfig.Consumer", config.Inmem},
+		{"kafkaconfig.Consumer", config.Kafka},
+		{"pubsubconfig.Consumer", config.Pubsub},
+		{"standardstreamconfig.Consumer", config.Standardstream},
 	}
 
 	for _, tt := range tests {
@@ -71,11 +71,11 @@ func TestNewProducer(t *testing.T) {
 		expected string
 		config   interface{}
 	}{
-		{"*streamconfig.Producer", config},
-		{"*inmemconfig.Producer", config.Inmem},
-		{"*kafkaconfig.Producer", config.Kafka},
-		{"*pubsubconfig.Producer", config.Pubsub},
-		{"*standardstreamconfig.Producer", config.Standardstream},
+		{"streamconfig.Producer", config},
+		{"inmemconfig.Producer", config.Inmem},
+		{"kafkaconfig.Producer", config.Kafka},
+		{"pubsubconfig.Producer", config.Pubsub},
+		{"standardstreamconfig.Producer", config.Standardstream},
 	}
 
 	for _, tt := range tests {

--- a/streamconfig/inmemconfig/client.go
+++ b/streamconfig/inmemconfig/client.go
@@ -1,0 +1,6 @@
+package inmemconfig
+
+// Client is a value-type, containing all user-configurable configuration values
+// that dictate how the instantiated inmem client will behave.
+type Client struct {
+}

--- a/streamconfig/inmemconfig/client.go
+++ b/streamconfig/inmemconfig/client.go
@@ -4,3 +4,6 @@ package inmemconfig
 // that dictate how the instantiated inmem client will behave.
 type Client struct {
 }
+
+// ClientDefaults holds the default values for Client.
+var ClientDefaults = Client{}

--- a/streamconfig/inmemconfig/client.go
+++ b/streamconfig/inmemconfig/client.go
@@ -1,9 +1,16 @@
 package inmemconfig
 
+import "go.uber.org/zap"
+
 // Client is a value-type, containing all user-configurable configuration values
 // that dictate how the instantiated inmem client will behave.
 type Client struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{}
+var ClientDefaults = Client{
+	Logger: zap.NewNop(),
+}

--- a/streamconfig/inmemconfig/client.go
+++ b/streamconfig/inmemconfig/client.go
@@ -10,7 +10,12 @@ type Client struct {
 	Logger *zap.Logger
 }
 
-// ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{
+// clientDefaults holds the default values for Client.
+var clientDefaults = Client{
 	Logger: zap.NewNop(),
+}
+
+// ClientDefaults returns the provided defaults.
+func ClientDefaults() Client {
+	return clientDefaults
 }

--- a/streamconfig/inmemconfig/client_test.go
+++ b/streamconfig/inmemconfig/client_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"go.uber.org/zap"
 )
 
 func TestClient(t *testing.T) {
-	_ = inmemconfig.Client{}
+	_ = inmemconfig.Client{
+		Logger: zap.NewNop(),
+	}
 }

--- a/streamconfig/inmemconfig/client_test.go
+++ b/streamconfig/inmemconfig/client_test.go
@@ -1,6 +1,7 @@
 package inmemconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
@@ -10,5 +11,16 @@ import (
 func TestClient(t *testing.T) {
 	_ = inmemconfig.Client{
 		Logger: zap.NewNop(),
+	}
+}
+
+func TestClientDefaults(t *testing.T) {
+	config := inmemconfig.ClientDefaults()
+
+	expected := "*zap.Logger"
+	actual := reflect.TypeOf(config.Logger).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
 	}
 }

--- a/streamconfig/inmemconfig/client_test.go
+++ b/streamconfig/inmemconfig/client_test.go
@@ -1,0 +1,11 @@
+package inmemconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+)
+
+func TestClient(t *testing.T) {
+	_ = inmemconfig.Client{}
+}

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -4,3 +4,6 @@ package inmemconfig
 // values that dictate how a inmem client's consumer will behave.
 type Consumer struct {
 }
+
+// ConsumerDefaults holds the default values for Consumer.
+var ConsumerDefaults = Consumer{}

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -5,5 +5,12 @@ package inmemconfig
 type Consumer struct {
 }
 
-// ConsumerDefaults holds the default values for Consumer.
-var ConsumerDefaults = Consumer{}
+// consumerDefaults holds the default values for Consumer.
+var consumerDefaults = Consumer{}
+
+// ConsumerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ConsumerDefaults(c Client) Consumer {
+	config := consumerDefaults
+	return config
+}

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -1,0 +1,6 @@
+package inmemconfig
+
+// Consumer is a value-type, containing all user-configurable configuration
+// values that dictate how a inmem client's consumer will behave.
+type Consumer struct {
+}

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -1,8 +1,13 @@
 package inmemconfig
 
+import "go.uber.org/zap"
+
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a inmem client's consumer will behave.
 type Consumer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // consumerDefaults holds the default values for Consumer.
@@ -12,5 +17,7 @@ var consumerDefaults = Consumer{}
 // client defaults to build the final defaults struct.
 func ConsumerDefaults(c Client) Consumer {
 	config := consumerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/inmemconfig/consumer_test.go
+++ b/streamconfig/inmemconfig/consumer_test.go
@@ -1,11 +1,27 @@
 package inmemconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	_ = inmemconfig.Consumer{}
+}
+
+func TestConsumerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := inmemconfig.Client{Logger: logger}
+	config := inmemconfig.ConsumerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/inmemconfig/consumer_test.go
+++ b/streamconfig/inmemconfig/consumer_test.go
@@ -1,0 +1,11 @@
+package inmemconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+)
+
+func TestConsumer(t *testing.T) {
+	_ = inmemconfig.Consumer{}
+}

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -1,0 +1,6 @@
+package inmemconfig
+
+// Producer is a value-type, containing all user-configurable configuration
+// values that dictate how a inmem client's producer will behave.
+type Producer struct {
+}

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -1,8 +1,13 @@
 package inmemconfig
 
+import "go.uber.org/zap"
+
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a inmem client's producer will behave.
 type Producer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // producerDefaults holds the default values for Producer.
@@ -12,5 +17,7 @@ var producerDefaults = Producer{}
 // client defaults to build the final defaults struct.
 func ProducerDefaults(c Client) Producer {
 	config := producerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -4,3 +4,6 @@ package inmemconfig
 // values that dictate how a inmem client's producer will behave.
 type Producer struct {
 }
+
+// ProducerDefaults holds the default values for Producer.
+var ProducerDefaults = Producer{}

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -5,5 +5,12 @@ package inmemconfig
 type Producer struct {
 }
 
-// ProducerDefaults holds the default values for Producer.
-var ProducerDefaults = Producer{}
+// producerDefaults holds the default values for Producer.
+var producerDefaults = Producer{}
+
+// ProducerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ProducerDefaults(c Client) Producer {
+	config := producerDefaults
+	return config
+}

--- a/streamconfig/inmemconfig/producer_test.go
+++ b/streamconfig/inmemconfig/producer_test.go
@@ -1,0 +1,11 @@
+package inmemconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+)
+
+func TestProducer(t *testing.T) {
+	_ = inmemconfig.Producer{}
+}

--- a/streamconfig/inmemconfig/producer_test.go
+++ b/streamconfig/inmemconfig/producer_test.go
@@ -1,11 +1,27 @@
 package inmemconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	_ = inmemconfig.Producer{}
+}
+
+func TestProducerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := inmemconfig.Client{Logger: logger}
+	config := inmemconfig.ProducerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/kafkaconfig/client.go
+++ b/streamconfig/kafkaconfig/client.go
@@ -1,0 +1,6 @@
+package kafkaconfig
+
+// Client is a value-type, containing all user-configurable configuration values
+// that dictate how the instantiated Kafka client will behave.
+type Client struct {
+}

--- a/streamconfig/kafkaconfig/client.go
+++ b/streamconfig/kafkaconfig/client.go
@@ -1,9 +1,16 @@
 package kafkaconfig
 
+import "go.uber.org/zap"
+
 // Client is a value-type, containing all user-configurable configuration values
 // that dictate how the instantiated Kafka client will behave.
 type Client struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{}
+var ClientDefaults = Client{
+	Logger: zap.NewNop(),
+}

--- a/streamconfig/kafkaconfig/client.go
+++ b/streamconfig/kafkaconfig/client.go
@@ -4,3 +4,6 @@ package kafkaconfig
 // that dictate how the instantiated Kafka client will behave.
 type Client struct {
 }
+
+// ClientDefaults holds the default values for Client.
+var ClientDefaults = Client{}

--- a/streamconfig/kafkaconfig/client.go
+++ b/streamconfig/kafkaconfig/client.go
@@ -10,7 +10,12 @@ type Client struct {
 	Logger *zap.Logger
 }
 
-// ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{
+// clientDefaults holds the default values for Client.
+var clientDefaults = Client{
 	Logger: zap.NewNop(),
+}
+
+// ClientDefaults returns the provided defaults.
+func ClientDefaults() Client {
+	return clientDefaults
 }

--- a/streamconfig/kafkaconfig/client_test.go
+++ b/streamconfig/kafkaconfig/client_test.go
@@ -1,6 +1,7 @@
 package kafkaconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
@@ -8,8 +9,18 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	_ = kafkaconfig.Client{}
 	_ = kafkaconfig.Client{
 		Logger: zap.NewNop(),
+	}
+}
+
+func TestClientDefaults(t *testing.T) {
+	config := kafkaconfig.ClientDefaults()
+
+	expected := "*zap.Logger"
+	actual := reflect.TypeOf(config.Logger).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
 	}
 }

--- a/streamconfig/kafkaconfig/client_test.go
+++ b/streamconfig/kafkaconfig/client_test.go
@@ -1,0 +1,11 @@
+package kafkaconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+)
+
+func TestClient(t *testing.T) {
+	_ = kafkaconfig.Client{}
+}

--- a/streamconfig/kafkaconfig/client_test.go
+++ b/streamconfig/kafkaconfig/client_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"go.uber.org/zap"
 )
 
 func TestClient(t *testing.T) {
 	_ = kafkaconfig.Client{}
+	_ = kafkaconfig.Client{
+		Logger: zap.NewNop(),
+	}
 }

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -1,8 +1,13 @@
 package kafkaconfig
 
+import "go.uber.org/zap"
+
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a Kafka client's consumer will behave.
 type Consumer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // consumerDefaults holds the default values for Consumer.
@@ -12,5 +17,7 @@ var consumerDefaults = Consumer{}
 // client defaults to build the final defaults struct.
 func ConsumerDefaults(c Client) Consumer {
 	config := consumerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -4,3 +4,6 @@ package kafkaconfig
 // values that dictate how a Kafka client's consumer will behave.
 type Consumer struct {
 }
+
+// ConsumerDefaults holds the default values for Consumer.
+var ConsumerDefaults = Consumer{}

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -1,0 +1,6 @@
+package kafkaconfig
+
+// Consumer is a value-type, containing all user-configurable configuration
+// values that dictate how a Kafka client's consumer will behave.
+type Consumer struct {
+}

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -5,5 +5,12 @@ package kafkaconfig
 type Consumer struct {
 }
 
-// ConsumerDefaults holds the default values for Consumer.
-var ConsumerDefaults = Consumer{}
+// consumerDefaults holds the default values for Consumer.
+var consumerDefaults = Consumer{}
+
+// ConsumerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ConsumerDefaults(c Client) Consumer {
+	config := consumerDefaults
+	return config
+}

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -1,11 +1,27 @@
 package kafkaconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	_ = kafkaconfig.Consumer{}
+}
+
+func TestConsumerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := kafkaconfig.Client{Logger: logger}
+	config := kafkaconfig.ConsumerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -1,0 +1,11 @@
+package kafkaconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+)
+
+func TestConsumer(t *testing.T) {
+	_ = kafkaconfig.Consumer{}
+}

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -4,3 +4,6 @@ package kafkaconfig
 // values that dictate how a Kafka client's producer will behave.
 type Producer struct {
 }
+
+// ProducerDefaults holds the default values for Producer.
+var ProducerDefaults = Producer{}

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -5,5 +5,12 @@ package kafkaconfig
 type Producer struct {
 }
 
-// ProducerDefaults holds the default values for Producer.
-var ProducerDefaults = Producer{}
+// producerDefaults holds the default values for Producer.
+var producerDefaults = Producer{}
+
+// ProducerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ProducerDefaults(c Client) Producer {
+	config := producerDefaults
+	return config
+}

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -1,8 +1,13 @@
 package kafkaconfig
 
+import "go.uber.org/zap"
+
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a Kafka client's producer will behave.
 type Producer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // producerDefaults holds the default values for Producer.
@@ -12,5 +17,7 @@ var producerDefaults = Producer{}
 // client defaults to build the final defaults struct.
 func ProducerDefaults(c Client) Producer {
 	config := producerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -1,0 +1,6 @@
+package kafkaconfig
+
+// Producer is a value-type, containing all user-configurable configuration
+// values that dictate how a Kafka client's producer will behave.
+type Producer struct {
+}

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -1,0 +1,11 @@
+package kafkaconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+)
+
+func TestProducer(t *testing.T) {
+	_ = kafkaconfig.Producer{}
+}

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -1,11 +1,27 @@
 package kafkaconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	_ = kafkaconfig.Producer{}
+}
+
+func TestProducerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := kafkaconfig.Client{Logger: logger}
+	config := kafkaconfig.ProducerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/pubsubconfig/client.go
+++ b/streamconfig/pubsubconfig/client.go
@@ -4,3 +4,6 @@ package pubsubconfig
 // that dictate how the instantiated Pubsub client will behave.
 type Client struct {
 }
+
+// ClientDefaults holds the default values for Client.
+var ClientDefaults = Client{}

--- a/streamconfig/pubsubconfig/client.go
+++ b/streamconfig/pubsubconfig/client.go
@@ -1,9 +1,16 @@
 package pubsubconfig
 
+import "go.uber.org/zap"
+
 // Client is a value-type, containing all user-configurable configuration values
 // that dictate how the instantiated Pubsub client will behave.
 type Client struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{}
+var ClientDefaults = Client{
+	Logger: zap.NewNop(),
+}

--- a/streamconfig/pubsubconfig/client.go
+++ b/streamconfig/pubsubconfig/client.go
@@ -1,0 +1,6 @@
+package pubsubconfig
+
+// Client is a value-type, containing all user-configurable configuration values
+// that dictate how the instantiated Pubsub client will behave.
+type Client struct {
+}

--- a/streamconfig/pubsubconfig/client.go
+++ b/streamconfig/pubsubconfig/client.go
@@ -10,7 +10,12 @@ type Client struct {
 	Logger *zap.Logger
 }
 
-// ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{
+// clientDefaults holds the default values for Client.
+var clientDefaults = Client{
 	Logger: zap.NewNop(),
+}
+
+// ClientDefaults returns the provided defaults.
+func ClientDefaults() Client {
+	return clientDefaults
 }

--- a/streamconfig/pubsubconfig/client_test.go
+++ b/streamconfig/pubsubconfig/client_test.go
@@ -1,6 +1,7 @@
 package pubsubconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
@@ -8,8 +9,18 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	_ = pubsubconfig.Client{}
 	_ = pubsubconfig.Client{
 		Logger: zap.NewNop(),
+	}
+}
+
+func TestClientDefaults(t *testing.T) {
+	config := pubsubconfig.ClientDefaults()
+
+	expected := "*zap.Logger"
+	actual := reflect.TypeOf(config.Logger).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
 	}
 }

--- a/streamconfig/pubsubconfig/client_test.go
+++ b/streamconfig/pubsubconfig/client_test.go
@@ -1,0 +1,11 @@
+package pubsubconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+)
+
+func TestClient(t *testing.T) {
+	_ = pubsubconfig.Client{}
+}

--- a/streamconfig/pubsubconfig/client_test.go
+++ b/streamconfig/pubsubconfig/client_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"go.uber.org/zap"
 )
 
 func TestClient(t *testing.T) {
 	_ = pubsubconfig.Client{}
+	_ = pubsubconfig.Client{
+		Logger: zap.NewNop(),
+	}
 }

--- a/streamconfig/pubsubconfig/consumer.go
+++ b/streamconfig/pubsubconfig/consumer.go
@@ -5,5 +5,12 @@ package pubsubconfig
 type Consumer struct {
 }
 
-// ConsumerDefaults holds the default values for Consumer.
-var ConsumerDefaults = Consumer{}
+// consumerDefaults holds the default values for Consumer.
+var consumerDefaults = Consumer{}
+
+// ConsumerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ConsumerDefaults(c Client) Consumer {
+	config := consumerDefaults
+	return config
+}

--- a/streamconfig/pubsubconfig/consumer.go
+++ b/streamconfig/pubsubconfig/consumer.go
@@ -1,8 +1,13 @@
 package pubsubconfig
 
+import "go.uber.org/zap"
+
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a Pubsub client's consumer will behave.
 type Consumer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // consumerDefaults holds the default values for Consumer.
@@ -12,5 +17,7 @@ var consumerDefaults = Consumer{}
 // client defaults to build the final defaults struct.
 func ConsumerDefaults(c Client) Consumer {
 	config := consumerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/pubsubconfig/consumer.go
+++ b/streamconfig/pubsubconfig/consumer.go
@@ -4,3 +4,6 @@ package pubsubconfig
 // values that dictate how a Pubsub client's consumer will behave.
 type Consumer struct {
 }
+
+// ConsumerDefaults holds the default values for Consumer.
+var ConsumerDefaults = Consumer{}

--- a/streamconfig/pubsubconfig/consumer.go
+++ b/streamconfig/pubsubconfig/consumer.go
@@ -1,0 +1,6 @@
+package pubsubconfig
+
+// Consumer is a value-type, containing all user-configurable configuration
+// values that dictate how a Pubsub client's consumer will behave.
+type Consumer struct {
+}

--- a/streamconfig/pubsubconfig/consumer_test.go
+++ b/streamconfig/pubsubconfig/consumer_test.go
@@ -1,11 +1,27 @@
 package pubsubconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	_ = pubsubconfig.Consumer{}
+}
+
+func TestConsumerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := pubsubconfig.Client{Logger: logger}
+	config := pubsubconfig.ConsumerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/pubsubconfig/consumer_test.go
+++ b/streamconfig/pubsubconfig/consumer_test.go
@@ -1,0 +1,11 @@
+package pubsubconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+)
+
+func TestConsumer(t *testing.T) {
+	_ = pubsubconfig.Consumer{}
+}

--- a/streamconfig/pubsubconfig/producer.go
+++ b/streamconfig/pubsubconfig/producer.go
@@ -4,3 +4,6 @@ package pubsubconfig
 // values that dictate how a Pubsub client's producer will behave.
 type Producer struct {
 }
+
+// ProducerDefaults holds the default values for Producer.
+var ProducerDefaults = Producer{}

--- a/streamconfig/pubsubconfig/producer.go
+++ b/streamconfig/pubsubconfig/producer.go
@@ -1,0 +1,6 @@
+package pubsubconfig
+
+// Producer is a value-type, containing all user-configurable configuration
+// values that dictate how a Pubsub client's producer will behave.
+type Producer struct {
+}

--- a/streamconfig/pubsubconfig/producer.go
+++ b/streamconfig/pubsubconfig/producer.go
@@ -5,5 +5,12 @@ package pubsubconfig
 type Producer struct {
 }
 
-// ProducerDefaults holds the default values for Producer.
-var ProducerDefaults = Producer{}
+// producerDefaults holds the default values for Producer.
+var producerDefaults = Producer{}
+
+// ProducerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ProducerDefaults(c Client) Producer {
+	config := producerDefaults
+	return config
+}

--- a/streamconfig/pubsubconfig/producer.go
+++ b/streamconfig/pubsubconfig/producer.go
@@ -1,8 +1,13 @@
 package pubsubconfig
 
+import "go.uber.org/zap"
+
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a Pubsub client's producer will behave.
 type Producer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
 }
 
 // producerDefaults holds the default values for Producer.
@@ -12,5 +17,7 @@ var producerDefaults = Producer{}
 // client defaults to build the final defaults struct.
 func ProducerDefaults(c Client) Producer {
 	config := producerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/pubsubconfig/producer_test.go
+++ b/streamconfig/pubsubconfig/producer_test.go
@@ -1,0 +1,11 @@
+package pubsubconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+)
+
+func TestProducer(t *testing.T) {
+	_ = pubsubconfig.Producer{}
+}

--- a/streamconfig/pubsubconfig/producer_test.go
+++ b/streamconfig/pubsubconfig/producer_test.go
@@ -1,11 +1,27 @@
 package pubsubconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	_ = pubsubconfig.Producer{}
+}
+
+func TestProducerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := pubsubconfig.Client{Logger: logger}
+	config := pubsubconfig.ProducerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/standardstreamconfig/client.go
+++ b/streamconfig/standardstreamconfig/client.go
@@ -1,0 +1,6 @@
+package standardstreamconfig
+
+// Client is a value-type, containing all user-configurable configuration values
+// that dictate how the instantiated standard stream client will behave.
+type Client struct {
+}

--- a/streamconfig/standardstreamconfig/client.go
+++ b/streamconfig/standardstreamconfig/client.go
@@ -1,9 +1,16 @@
 package standardstreamconfig
 
+import "go.uber.org/zap"
+
 // Client is a value-type, containing all user-configurable configuration values
 // that dictate how the instantiated standard stream client will behave.
 type Client struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a noop logger will be used.
+	Logger *zap.Logger
 }
 
 // ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{}
+var ClientDefaults = Client{
+	Logger: zap.NewNop(),
+}

--- a/streamconfig/standardstreamconfig/client.go
+++ b/streamconfig/standardstreamconfig/client.go
@@ -4,3 +4,6 @@ package standardstreamconfig
 // that dictate how the instantiated standard stream client will behave.
 type Client struct {
 }
+
+// ClientDefaults holds the default values for Client.
+var ClientDefaults = Client{}

--- a/streamconfig/standardstreamconfig/client.go
+++ b/streamconfig/standardstreamconfig/client.go
@@ -10,7 +10,12 @@ type Client struct {
 	Logger *zap.Logger
 }
 
-// ClientDefaults holds the default values for Client.
-var ClientDefaults = Client{
+// clientDefaults holds the default values for Client.
+var clientDefaults = Client{
 	Logger: zap.NewNop(),
+}
+
+// ClientDefaults returns the provided defaults.
+func ClientDefaults() Client {
+	return clientDefaults
 }

--- a/streamconfig/standardstreamconfig/client_test.go
+++ b/streamconfig/standardstreamconfig/client_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"go.uber.org/zap"
 )
 
 func TestClient(t *testing.T) {
 	_ = standardstreamconfig.Client{}
+	_ = standardstreamconfig.Client{
+		Logger: zap.NewNop(),
+	}
 }

--- a/streamconfig/standardstreamconfig/client_test.go
+++ b/streamconfig/standardstreamconfig/client_test.go
@@ -1,6 +1,7 @@
 package standardstreamconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
@@ -8,8 +9,18 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	_ = standardstreamconfig.Client{}
 	_ = standardstreamconfig.Client{
 		Logger: zap.NewNop(),
+	}
+}
+
+func TestClientDefaults(t *testing.T) {
+	config := standardstreamconfig.ClientDefaults()
+
+	expected := "*zap.Logger"
+	actual := reflect.TypeOf(config.Logger).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
 	}
 }

--- a/streamconfig/standardstreamconfig/client_test.go
+++ b/streamconfig/standardstreamconfig/client_test.go
@@ -1,0 +1,11 @@
+package standardstreamconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+func TestClient(t *testing.T) {
+	_ = standardstreamconfig.Client{}
+}

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -1,0 +1,5 @@
+package standardstreamconfig
+
+// Consumer is a value-type, containing all user-configurable configuration
+// values that dictate how a standard stream client's consumer will behave.
+type Consumer struct{}

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -1,8 +1,14 @@
 package standardstreamconfig
 
+import "go.uber.org/zap"
+
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's consumer will behave.
-type Consumer struct{}
+type Consumer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
+}
 
 // consumerDefaults holds the default values for Consumer.
 var consumerDefaults = Consumer{}
@@ -11,5 +17,7 @@ var consumerDefaults = Consumer{}
 // client defaults to build the final defaults struct.
 func ConsumerDefaults(c Client) Consumer {
 	config := consumerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -4,5 +4,12 @@ package standardstreamconfig
 // values that dictate how a standard stream client's consumer will behave.
 type Consumer struct{}
 
-// ConsumerDefaults holds the default values for Consumer.
-var ConsumerDefaults = Consumer{}
+// consumerDefaults holds the default values for Consumer.
+var consumerDefaults = Consumer{}
+
+// ConsumerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ConsumerDefaults(c Client) Consumer {
+	config := consumerDefaults
+	return config
+}

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -3,3 +3,6 @@ package standardstreamconfig
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's consumer will behave.
 type Consumer struct{}
+
+// ConsumerDefaults holds the default values for Consumer.
+var ConsumerDefaults = Consumer{}

--- a/streamconfig/standardstreamconfig/consumer_test.go
+++ b/streamconfig/standardstreamconfig/consumer_test.go
@@ -1,11 +1,27 @@
 package standardstreamconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	_ = standardstreamconfig.Consumer{}
+}
+
+func TestConsumerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := standardstreamconfig.Client{Logger: logger}
+	config := standardstreamconfig.ConsumerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/standardstreamconfig/consumer_test.go
+++ b/streamconfig/standardstreamconfig/consumer_test.go
@@ -1,0 +1,11 @@
+package standardstreamconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+func TestConsumer(t *testing.T) {
+	_ = standardstreamconfig.Consumer{}
+}

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -1,8 +1,14 @@
 package standardstreamconfig
 
+import "go.uber.org/zap"
+
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's producer will behave.
-type Producer struct{}
+type Producer struct {
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, the client's configured logger will be used.
+	Logger *zap.Logger
+}
 
 // producerDefaults holds the default values for Producer.
 var producerDefaults = Producer{}
@@ -11,5 +17,7 @@ var producerDefaults = Producer{}
 // client defaults to build the final defaults struct.
 func ProducerDefaults(c Client) Producer {
 	config := producerDefaults
+	config.Logger = c.Logger
+
 	return config
 }

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -3,3 +3,6 @@ package standardstreamconfig
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's producer will behave.
 type Producer struct{}
+
+// ProducerDefaults holds the default values for Producer.
+var ProducerDefaults = Producer{}

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -4,5 +4,12 @@ package standardstreamconfig
 // values that dictate how a standard stream client's producer will behave.
 type Producer struct{}
 
-// ProducerDefaults holds the default values for Producer.
-var ProducerDefaults = Producer{}
+// producerDefaults holds the default values for Producer.
+var producerDefaults = Producer{}
+
+// ProducerDefaults returns the provided defaults, optionally using pre-defined
+// client defaults to build the final defaults struct.
+func ProducerDefaults(c Client) Producer {
+	config := producerDefaults
+	return config
+}

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -1,0 +1,5 @@
+package standardstreamconfig
+
+// Producer is a value-type, containing all user-configurable configuration
+// values that dictate how a standard stream client's producer will behave.
+type Producer struct{}

--- a/streamconfig/standardstreamconfig/producer_test.go
+++ b/streamconfig/standardstreamconfig/producer_test.go
@@ -1,11 +1,27 @@
 package standardstreamconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	_ = standardstreamconfig.Producer{}
+}
+
+func TestProducerDefaults(t *testing.T) {
+	logger := zap.NewExample()
+
+	cc := standardstreamconfig.Client{Logger: logger}
+	config := standardstreamconfig.ProducerDefaults(cc)
+
+	expected := logger
+	actual := config.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
 }

--- a/streamconfig/standardstreamconfig/producer_test.go
+++ b/streamconfig/standardstreamconfig/producer_test.go
@@ -1,0 +1,11 @@
+package standardstreamconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+func TestProducer(t *testing.T) {
+	_ = standardstreamconfig.Producer{}
+}


### PR DESCRIPTION
This is a work-in-progress. I'm going to create several PRs, all based off of each other. I'll be working on this on-and-off again in my evening hours as a fun project, but feel free to block some time to review the PRs, as I think it's important we do this right, before we start using this in many more processors in the future.

---

This adds the different packages for the client configurations. The major difference with the old system was that we tried to shoehorn the different client implementations to use the same configuration names and values, which just doesn't work, when the clients themselves behave very differently.

Also, we can now cleanly define configuration defaults, and read back any configuration set using `Config()`, which might come in handy for logging purposes, but at least comes in handy during testing.