### PR TITLE
Initial standardstreamclient implementation

### DIFF
--- a/script/test
+++ b/script/test
@@ -10,4 +10,3 @@ script/tests/gometalinter
 script/tests/go-test
 script/tests/go-test-race
 script/tests/go-test-bench
-script/tests/godog

--- a/script/tests/go-test-bench
+++ b/script/tests/go-test-bench
@@ -6,4 +6,4 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-go test -bench . -benchmem ${@:-./...}
+go test -bench . -run='^$' -v -benchmem ${@:-./...}

--- a/script/tests/gometalinter
+++ b/script/tests/gometalinter
@@ -27,9 +27,7 @@ gometalinter \
   --deadline=300s \
   --vendored-linters \
   --enable-all \
-  --disable=gotype \
-  --disable=gas \
-  --disable=lll \
-  --disable=gocyclo \
+  --line-length=100 \
   --disable=dupl \
+  --linter='lll:lll -e func -g -l {maxlinelength}:PATH:LINE:MESSAGE' \
   ${@:-./...}

--- a/streamclient/standardstreamclient/client.go
+++ b/streamclient/standardstreamclient/client.go
@@ -1,0 +1,40 @@
+package standardstreamclient
+
+import (
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+// Client implements the stream.Client interface for the standard stream client.
+type Client struct {
+	// config represents the relevant portion of the configuration passed into the
+	// stream processor its initialization function.
+	config standardstreamconfig.Client
+
+	// rawConfig represents the as-is configuration passed into the stream
+	// proceesor its initialization function by the user. This includes the
+	// configuration of other streamclient implementations, irrelevant to the
+	// current implementation.
+	rawConfig streamconfig.Client
+}
+
+// New returns a new standard stream client.
+func New(options ...func(*streamconfig.Client)) (stream.Client, error) {
+	config, err := streamconfig.NewClient(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		config:    config.Standardstream,
+		rawConfig: config,
+	}
+
+	return client, nil
+}
+
+// Config returns a read-only representation of the client configuration.
+func (c *Client) Config() streamconfig.Client {
+	return c.rawConfig
+}

--- a/streamclient/standardstreamclient/client_test.go
+++ b/streamclient/standardstreamclient/client_test.go
@@ -1,0 +1,54 @@
+package standardstreamclient_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"go.uber.org/zap"
+)
+
+func TestClient(t *testing.T) {
+	t.Parallel()
+
+	_ = standardstreamclient.Client{}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := "*standardstreamclient.Client"
+	actual := reflect.TypeOf(client).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNew_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	logger := zap.NewExample()
+
+	options := func(c *streamconfig.Client) {
+		c.Standardstream.Logger = logger
+	}
+
+	client, err := standardstreamclient.New(options)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := logger
+	actual := client.Config().Standardstream.Logger
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -66,7 +66,6 @@ func (c *Client) NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Co
 			// a new permanent copy of the value, to prevent a scenario where the
 			// reader of the channel reads the value too late, resulting in unexpected
 			// data being returned.
-			//
 			b := make([]byte, len(scanner.Bytes()))
 			copy(b, scanner.Bytes())
 

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -1,0 +1,118 @@
+package standardstreamclient
+
+import (
+	"bufio"
+	"sync"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+// maxCapacity represents the maximum number of tokens supported per-line. This
+// is set to a reasonable high value, to support most use-cases, without
+// allocating too much wasted memory. For now, this is hard-coded. If we ever
+// have a need, we can move this to the standardstreamconfig package.
+const maxCapacity = 512 * 1024
+
+// Consumer implements the stream.Consumer interface for the standard stream
+// client.
+type Consumer struct {
+	// config represents the relevant portion of the configuration passed into the
+	// consumer its initialization function.
+	config standardstreamconfig.Consumer
+
+	// rawConfig represents the as-is configuration passed into the consumer its
+	// initialization function by the user. This includes the configuration of
+	// other consumer implementations, irrelevant to the current implementation.
+	rawConfig streamconfig.Consumer
+
+	wg       sync.WaitGroup
+	messages chan *stream.Message
+}
+
+// NewConsumer returns a new standard stream consumer.
+func (c *Client) NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+	consumer, err := newConsumer(c, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// add one to the WaitGroup. We remove this one only after all reads (below)
+	// are completed and the read channel is closed.
+	consumer.wg.Add(1)
+
+	go func() {
+		// scanner.Scan() stops once it reached the last line of the provided
+		// reader. When it does, we close the read channel, making sure any blocking
+		// consumers are unblocked. We also reduce the WaitGroup count by one
+		// (making the total count zero), making sure we unblock any subsequent call
+		// to consumer.Close().
+		defer func() {
+			close(consumer.messages)
+			consumer.wg.Done()
+		}()
+
+		scanner := bufio.NewScanner(consumer.config.Reader)
+		buf := make([]byte, 0, maxCapacity)
+		scanner.Buffer(buf, maxCapacity)
+
+		for scanner.Scan() {
+			// scanner.Bytes() does not allocate any new memory for the returned
+			// bytes. This means that during the next scan, the memory will be re-used
+			// for the value of the next line.
+			//
+			// Since we pass this value to the messages channel, we need to allocate
+			// a new permanent copy of the value, to prevent a scenario where the
+			// reader of the channel reads the value too late, resulting in unexpected
+			// data being returned.
+			//
+			b := make([]byte, len(scanner.Bytes()))
+			copy(b, scanner.Bytes())
+
+			consumer.messages <- &stream.Message{Value: b}
+		}
+	}()
+
+	return consumer, nil
+}
+
+// Messages returns the read channel for the messages that are returned by the
+// stream.
+func (c *Consumer) Messages() <-chan *stream.Message {
+	return c.messages
+}
+
+// Close closes the consumer connection.
+func (c *Consumer) Close() error {
+	err := c.config.Reader.Close()
+	if err != nil {
+		return err
+	}
+
+	// Wait until the WaitGroup counter is zero. This makes sure we block the
+	// close call until the reader has been closed, to prevent reading errors.
+	c.wg.Wait()
+
+	return nil
+}
+
+// Config returns a read-only representation of the consumer configuration.
+func (c *Consumer) Config() streamconfig.Consumer {
+	return c.rawConfig
+}
+
+func newConsumer(c *Client, options []func(*streamconfig.Consumer)) (*Consumer, error) {
+	config, err := streamconfig.NewConsumer(c.rawConfig, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	consumer := &Consumer{
+		config:    config.Standardstream,
+		rawConfig: config,
+		messages:  make(chan *stream.Message),
+	}
+
+	return consumer, nil
+}

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -1,0 +1,129 @@
+package standardstreamclient_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+func TestConsumer(t *testing.T) {
+	t.Parallel()
+
+	_ = standardstreamclient.Consumer{}
+}
+
+func TestNewConsumer(t *testing.T) {
+	t.Parallel()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	consumer, err := client.NewConsumer()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := "*standardstreamclient.Consumer"
+	actual := reflect.TypeOf(consumer).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewConsumer_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	f, _ := ioutil.TempFile("", "")
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Consumer) {
+		c.Standardstream.Reader = f
+	}
+
+	consumer, err := client.NewConsumer(options)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := f
+	actual := consumer.Config().Standardstream.Reader
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewConsumer_Messages(t *testing.T) {
+	t.Parallel()
+
+	f, _ := ioutil.TempFile("", "")
+	_, err := f.WriteString("hello world\nhello universe!")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Consumer) {
+		c.Standardstream.Reader = f
+	}
+
+	consumer, err := client.NewConsumer(options)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	msg := <-consumer.Messages()
+
+	expected := "hello world"
+	actual := string(msg.Value)
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+
+	msg = <-consumer.Messages()
+
+	expected = "hello universe!"
+	actual = string(msg.Value)
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+
+	_, ok := <-consumer.Messages()
+	if ok {
+		t.Errorf("Channel is not closed")
+	}
+}

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -1,11 +1,16 @@
 package standardstreamclient_test
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 )
@@ -40,13 +45,8 @@ func TestNewConsumer(t *testing.T) {
 func TestNewConsumer_WithOptions(t *testing.T) {
 	t.Parallel()
 
-	f, _ := ioutil.TempFile("", "")
-	defer func() {
-		err := os.Remove(f.Name())
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-	}()
+	f, closer := createTestFile(t, nil)
+	defer closer()
 
 	client, err := standardstreamclient.New()
 	if err != nil {
@@ -73,36 +73,11 @@ func TestNewConsumer_WithOptions(t *testing.T) {
 func TestNewConsumer_Messages(t *testing.T) {
 	t.Parallel()
 
-	f, _ := ioutil.TempFile("", "")
-	_, err := f.WriteString("hello world\nhello universe!")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	f, closer := createTestFile(t, []byte("hello world\nhello universe!"))
+	defer closer()
 
-	_, err = f.Seek(0, 0)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	defer func() {
-		err := os.Remove(f.Name())
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-	}()
-
-	client, err := standardstreamclient.New()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	options := func(c *streamconfig.Consumer) {
-		c.Standardstream.Reader = f
-	}
-
-	consumer, err := client.NewConsumer(options)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	consumer, closer := newConsumer(t, f)
+	defer closer()
 
 	msg := <-consumer.Messages()
 
@@ -126,4 +101,134 @@ func TestNewConsumer_Messages(t *testing.T) {
 	if ok {
 		t.Errorf("Channel is not closed")
 	}
+}
+
+func TestNewConsumer_MessageOrdering(t *testing.T) {
+	t.Parallel()
+
+	messageCount := 100000
+	fileContents := []byte("")
+
+	for i := 0; i < messageCount; i++ {
+		fileContents = append(fileContents, []byte(strconv.Itoa(i)+"\n")...)
+	}
+
+	f, closer := createTestFile(t, fileContents)
+	defer closer()
+
+	consumer, closer := newConsumer(t, f)
+	defer closer()
+
+	i := 0
+	for msg := range consumer.Messages() {
+		if strconv.Itoa(i) != string(msg.Value) {
+			t.Fatalf("Expected %q to equal %d", msg.Value, i)
+		}
+
+		i++
+	}
+}
+
+func TestNewConsumer_PerMessageMemoryAllocation(t *testing.T) {
+	t.Parallel()
+
+	messageCount := 100000
+	fileContents := []byte("")
+	line := `{"number":%d}` + "\n"
+
+	for i := 0; i < messageCount; i++ {
+		fileContents = append(fileContents, []byte(fmt.Sprintf(line, i))...)
+	}
+
+	f, closer := createTestFile(t, fileContents)
+	defer closer()
+
+	consumer, closer := newConsumer(t, f)
+	defer closer()
+
+	i := 0
+	for msg := range consumer.Messages() {
+		// By making this test do some "work" during the processing of a message, we
+		// trigger a potential race condition where the actual value of the message
+		// is already replaced with a newer message in the channel. This is fixed in
+		// this consumer's implementation, but without this test, we couldn't expose
+		// the actual problem.
+		m := bytes.Split(msg.Value, []byte(`"number":`))
+		m = bytes.Split(m[1], []byte(`}`))
+
+		expected := strconv.Itoa(i)
+		actual := string(m[0])
+		if actual != expected {
+			t.Errorf("Unexpected return value, expected %s, got %s", expected, actual)
+		}
+
+		i++
+	}
+}
+
+func BenchmarkConsumer_Messages(b *testing.B) {
+	fileContents := []byte("")
+	line := `{"number":%d}` + "\n"
+
+	for i := 1; i <= b.N; i++ {
+		fileContents = append(fileContents, []byte(fmt.Sprintf(line, i))...)
+	}
+
+	f, closer := createTestFile(b, fileContents)
+	defer closer()
+
+	b.ResetTimer()
+
+	consumer, closer := newConsumer(b, f)
+	defer closer()
+
+	for range consumer.Messages() {
+	}
+}
+
+func newConsumer(tb testing.TB, r io.ReadCloser) (stream.Consumer, func()) {
+	client, err := standardstreamclient.New()
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Consumer) {
+		c.Standardstream.Reader = r
+	}
+
+	consumer, err := client.NewConsumer(options)
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	fn := func() {
+		err = consumer.Close()
+		if err != nil {
+			tb.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	return consumer, fn
+}
+
+func createTestFile(tb testing.TB, b []byte) (*os.File, func()) {
+	f, _ := ioutil.TempFile("", "")
+	_, err := f.Write(b)
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	fn := func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			tb.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	return f, fn
 }

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -1,0 +1,98 @@
+package standardstreamclient
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+)
+
+// Producer implements the stream.Producer interface for the standard stream
+// client.
+type Producer struct {
+	// config represents the relevant portion of the configuration passed into the
+	// producer its initialization function.
+	config standardstreamconfig.Producer
+
+	// rawConfig represents the as-is configuration passed into the producer its
+	// initialization function by the user. This includes the configuration of
+	// other producer implementations, irrelevant to the current implementation.
+	rawConfig streamconfig.Producer
+
+	wg       sync.WaitGroup
+	messages chan<- *stream.Message
+}
+
+// NewProducer returns a new standard stream producer.
+func (c *Client) NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+	ch := make(chan *stream.Message)
+
+	producer, err := newProducer(c, ch, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// add one to the WaitGroup. We remove this one only after all writes (below)
+	// are completed and the write channel is closed.
+	producer.wg.Add(1)
+
+	go func() {
+		defer producer.wg.Done()
+
+		for msg := range ch {
+			message := msg.Value
+
+			// If the original message does not contain a newline at the end, we add
+			// it, as this is used as the message delimiter.
+			if !bytes.HasSuffix(message, []byte("\n")) {
+				message = append(message, "\n"...)
+			}
+
+			_, err := producer.config.Writer.Write(message)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}()
+
+	return producer, nil
+}
+
+// Messages returns the write channel for messages to be produced.
+func (p *Producer) Messages() chan<- *stream.Message {
+	return p.messages
+}
+
+// Close closes the producer connection. This function blocks until all messages
+// still in the channel have been processed, and the channel is properly closed.
+func (p *Producer) Close() error {
+	close(p.messages)
+
+	// Wait until the WaitGroup counter is zero. This makes sure we block the
+	// close call until all messages have been delivered, to prevent data-loss.
+	p.wg.Wait()
+
+	return nil
+}
+
+// Config returns a read-only representation of the producer configuration.
+func (p *Producer) Config() streamconfig.Producer {
+	return p.rawConfig
+}
+
+func newProducer(c *Client, ch chan *stream.Message, options []func(*streamconfig.Producer)) (*Producer, error) {
+	config, err := streamconfig.NewProducer(c.rawConfig, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	producer := &Producer{
+		config:    config.Standardstream,
+		rawConfig: config,
+		messages:  ch,
+	}
+
+	return producer, nil
+}

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -3,9 +3,10 @@ package standardstreamclient_test
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
-	"os"
+	"fmt"
+	"io"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/stream"
@@ -32,6 +33,13 @@ func TestNewProducer(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	defer func() {
+		err = producer.Close()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}()
+
 	expected := "*standardstreamclient.Producer"
 	actual := reflect.TypeOf(producer).String()
 
@@ -41,39 +49,6 @@ func TestNewProducer(t *testing.T) {
 }
 
 func TestNewProducer_WithOptions(t *testing.T) {
-	t.Parallel()
-
-	f, _ := ioutil.TempFile("", "")
-	defer func() {
-		err := os.Remove(f.Name())
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-	}()
-
-	client, err := standardstreamclient.New()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	options := func(c *streamconfig.Producer) {
-		c.Standardstream.Writer = f
-	}
-
-	producer, err := client.NewProducer(options)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	expected := f
-	actual := producer.Config().Standardstream.Writer
-
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Expected %v to equal %v", actual, expected)
-	}
-}
-
-func TestNewProducer_Messages(t *testing.T) {
 	t.Parallel()
 
 	var b bytes.Buffer
@@ -93,15 +68,34 @@ func TestNewProducer_Messages(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	defer func() {
+		err = producer.Close()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}()
+
+	expected := f
+	actual := producer.Config().Standardstream.Writer
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewProducer_Messages(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	f := bufio.NewWriter(&b)
 	expected := "hello world\n"
 
-	producer.Messages() <- &stream.Message{Value: []byte(expected)}
-	err = producer.Close()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	producer, closer := newProducer(t, f)
 
-	err = f.Flush()
+	producer.Messages() <- &stream.Message{Value: []byte(expected)}
+	closer()
+
+	err := f.Flush()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -111,4 +105,107 @@ func TestNewProducer_Messages(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Expected %v to equal %v", actual, expected)
 	}
+}
+
+func TestNewProducer_AppendNewline(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	f := bufio.NewWriter(&b)
+	expected := "hello world\n"
+
+	producer, closer := newProducer(t, f)
+
+	producer.Messages() <- &stream.Message{Value: []byte("hello world")}
+	closer()
+
+	err := f.Flush()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	actual := b.String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewProducer_MessageOrdering(t *testing.T) {
+	t.Parallel()
+
+	messageCount := 100000
+
+	var b bytes.Buffer
+	f := bufio.NewWriter(&b)
+
+	producer, closer := newProducer(t, f)
+
+	for i := 0; i < messageCount; i++ {
+		producer.Messages() <- &stream.Message{Value: []byte(strconv.Itoa(i))}
+	}
+	closer()
+
+	err := f.Flush()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	i := 0
+	scanner := bufio.NewScanner(bytes.NewReader(b.Bytes()))
+	for scanner.Scan() {
+		expected := strconv.Itoa(i)
+		actual := scanner.Text()
+
+		if actual != expected {
+			t.Errorf("Expected %v to equal %v", actual, expected)
+		}
+
+		i++
+	}
+
+	if err = scanner.Err(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func BenchmarkProducer_Messages(b *testing.B) {
+	var bb bytes.Buffer
+	f := bufio.NewWriter(&bb)
+
+	producer, closer := newProducer(b, f)
+	defer closer()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		producer.Messages() <- &stream.Message{
+			Value: []byte(fmt.Sprintf(`{"number":%d}`, i)),
+		}
+	}
+}
+
+func newProducer(tb testing.TB, w io.Writer) (stream.Producer, func()) {
+	client, err := standardstreamclient.New()
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Producer) {
+		c.Standardstream.Writer = w
+	}
+
+	producer, err := client.NewProducer(options)
+	if err != nil {
+		tb.Fatalf("Unexpected error: %v", err)
+	}
+
+	fn := func() {
+		err = producer.Close()
+		if err != nil {
+			tb.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	return producer, fn
 }

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -1,0 +1,114 @@
+package standardstreamclient_test
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+func TestProducer(t *testing.T) {
+	t.Parallel()
+
+	_ = standardstreamclient.Producer{}
+}
+
+func TestNewProducer(t *testing.T) {
+	t.Parallel()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	producer, err := client.NewProducer()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := "*standardstreamclient.Producer"
+	actual := reflect.TypeOf(producer).String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewProducer_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	f, _ := ioutil.TempFile("", "")
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}()
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Producer) {
+		c.Standardstream.Writer = f
+	}
+
+	producer, err := client.NewProducer(options)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := f
+	actual := producer.Config().Standardstream.Writer
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func TestNewProducer_Messages(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	f := bufio.NewWriter(&b)
+
+	client, err := standardstreamclient.New()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	options := func(c *streamconfig.Producer) {
+		c.Standardstream.Writer = f
+	}
+
+	producer, err := client.NewProducer(options)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expected := "hello world\n"
+
+	producer.Messages() <- &stream.Message{Value: []byte(expected)}
+	err = producer.Close()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	err = f.Flush()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	actual := b.String()
+
+	if actual != expected {
+		t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -1,6 +1,11 @@
 package standardstreamconfig
 
-import "go.uber.org/zap"
+import (
+	"io"
+	"os"
+
+	"go.uber.org/zap"
+)
 
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's consumer will behave.
@@ -8,10 +13,17 @@ type Consumer struct {
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, the client's configured logger will be used.
 	Logger *zap.Logger
+
+	// Reader is the object that implements the io.ReadCloser interface
+	// (io.Reader + io.Closer). This object is used to read messages from the
+	// stream. Defaults to `consumerDefaults.Reader`.
+	Reader io.ReadCloser
 }
 
 // consumerDefaults holds the default values for Consumer.
-var consumerDefaults = Consumer{}
+var consumerDefaults = Consumer{
+	Reader: os.Stdin,
+}
 
 // ConsumerDefaults returns the provided defaults, optionally using pre-defined
 // client defaults to build the final defaults struct.

--- a/streamconfig/standardstreamconfig/consumer_test.go
+++ b/streamconfig/standardstreamconfig/consumer_test.go
@@ -1,6 +1,7 @@
 package standardstreamconfig_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -11,7 +12,9 @@ import (
 func TestConsumer(t *testing.T) {
 	t.Parallel()
 
-	_ = standardstreamconfig.Consumer{}
+	_ = standardstreamconfig.Consumer{
+		Reader: os.Stdin,
+	}
 }
 
 func TestConsumerDefaults(t *testing.T) {

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -1,6 +1,11 @@
 package standardstreamconfig
 
-import "go.uber.org/zap"
+import (
+	"io"
+	"os"
+
+	"go.uber.org/zap"
+)
 
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a standard stream client's producer will behave.
@@ -8,10 +13,17 @@ type Producer struct {
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, the client's configured logger will be used.
 	Logger *zap.Logger
+
+	// Writer is the object that implements the io.Writer interface. This object
+	// is used to write new messages to the stream. Defaults to
+	// `producerDefaults.Writer`.
+	Writer io.Writer
 }
 
 // producerDefaults holds the default values for Producer.
-var producerDefaults = Producer{}
+var producerDefaults = Producer{
+	Writer: os.Stdout,
+}
 
 // ProducerDefaults returns the provided defaults, optionally using pre-defined
 // client defaults to build the final defaults struct.

--- a/streamconfig/standardstreamconfig/producer_test.go
+++ b/streamconfig/standardstreamconfig/producer_test.go
@@ -1,6 +1,7 @@
 package standardstreamconfig_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -11,7 +12,9 @@ import (
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
-	_ = standardstreamconfig.Producer{}
+	_ = standardstreamconfig.Producer{
+		Writer: os.Stdout,
+	}
 }
 
 func TestProducerDefaults(t *testing.T) {


### PR DESCRIPTION
This is a work-in-progress. I'm going to create several PRs, all based off of each other. I'll be working on this on-and-off again in my evening hours as a fun project, but feel free to block some time to review the PRs, as I think it's important we do this right, before we start using this in many more processors in the future.

---

This adds the initial `standardstreamclient` implementation.

Still to do:

- document in README
- more unit testing
- benchmark tests (not really relevant for this client, but a good way to create the framework for future benchmark tests)
- cucumber tests (re-usable for other client implementations following in subsequent PRs)