### PR TITLE
 Add standardstream.NewConsumer/Producer functions

### DIFF
--- a/streamclient/consumer.go
+++ b/streamclient/consumer.go
@@ -1,0 +1,46 @@
+package streamclient
+
+import (
+	"errors"
+	"os"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
+	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
+	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+// NewConsumer returns a new streamclient consumer, based on the context from
+// which this function is called.
+func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+	switch os.Getenv("STREAMCLIENT_CONSUMER") {
+	case "standardstream":
+		return standardstreamclient.NewConsumer(options...)
+	case "inmem":
+		return inmemclient.NewConsumer(options...)
+	case "kafka":
+		return kafkaclient.NewConsumer(options...)
+	case "pubsub":
+		return nil, errors.New("pubsub consumer not implemented yet")
+	}
+
+	if stdinPipePresent() {
+		return standardstreamclient.NewConsumer(options...)
+	}
+
+	return nil, errors.New("unable to determine required consumer streamclient")
+}
+
+func stdinPipePresent() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+
+	if fi.Mode()&os.ModeNamedPipe == 0 {
+		return false
+	}
+
+	return true
+}

--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -1,0 +1,105 @@
+package streamclient_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamclient"
+	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamutils/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConsumer(t *testing.T) {
+	t.Parallel()
+
+	_, err := streamclient.NewConsumer()
+	assert.Error(t, err)
+}
+
+func TestIntegrationNewConsumer_Env(t *testing.T) {
+	testutils.Integration(t)
+
+	var tests = []struct {
+		env    string
+		typeOf string
+		opts   func(*streamconfig.Consumer)
+	}{
+		{
+			"standardstream",
+			"*standardstreamclient.Consumer",
+			nil,
+		},
+
+		{
+			"inmem",
+			"*inmemclient.Consumer",
+			nil,
+		},
+
+		{
+			"kafka",
+			"*kafkaclient.Consumer",
+			func(c *streamconfig.Consumer) {
+				c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+				c.Kafka.Topics = []string{"test"}
+				c.Kafka.GroupID = "test"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			os.Setenv("STREAMCLIENT_CONSUMER", tt.env)
+			defer os.Unsetenv("STREAMCLIENT_CONSUMER")
+
+			consumer, err := streamclient.NewConsumer(tt.opts)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.typeOf, reflect.TypeOf(consumer).String())
+		})
+	}
+}
+
+func TestIntegrationNewConsumer_Pubsub(t *testing.T) {
+	os.Setenv("STREAMCLIENT_CONSUMER", "pubsub")
+	defer os.Unsetenv("STREAMCLIENT_CONSUMER")
+
+	_, err := streamclient.NewConsumer()
+	assert.Error(t, err)
+}
+
+func TestIntegrationNewConsumer_PipedData(t *testing.T) {
+	if os.Getenv("BE_TESTING_STDIN") == "1" {
+		consumer, err := streamclient.NewConsumer()
+		require.NoError(t, err)
+
+		require.Equal(t, "*standardstreamclient.Consumer", reflect.TypeOf(consumer).String())
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+	cmd.Env = append(os.Environ(), "BE_TESTING_STDIN=1")
+
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	defer stdin.Close()
+
+	io.WriteString(stdin, `{ "hello": "world" }`)
+
+	b, err := cmd.CombinedOutput()
+	if e, ok := err.(*exec.ExitError); ok {
+		assert.True(t, e.Success(), fmt.Sprintf("%s\n\n%s", e.String(), string(b)))
+	}
+}
+
+func TestIntegrationNewConsumer_Unknown(t *testing.T) {
+	_, err := streamclient.NewConsumer()
+	assert.Error(t, err)
+}

--- a/streamclient/producer.go
+++ b/streamclient/producer.go
@@ -1,0 +1,33 @@
+package streamclient
+
+import (
+	"errors"
+	"os"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
+	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
+	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+)
+
+// NewProducer returns a new streamclient producer, based on the context from
+// which this function is called.
+func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+	switch os.Getenv("STREAMCLIENT_PRODUCER") {
+	case "standardstream":
+		return standardstreamclient.NewProducer(options...)
+	case "inmem":
+		return inmemclient.NewProducer(options...)
+	case "kafka":
+		return kafkaclient.NewProducer(options...)
+	case "pubsub":
+		return nil, errors.New("pubsub producer not implemented yet")
+	}
+
+	if os.Getenv("DRY_RUN") != "" {
+		return standardstreamclient.NewProducer(options...)
+	}
+
+	return nil, errors.New("unable to determine required producer streamclient")
+}

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -1,0 +1,100 @@
+package streamclient_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamclient"
+	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamutils/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProducer(t *testing.T) {
+	t.Parallel()
+
+	_, err := streamclient.NewProducer()
+	assert.Error(t, err)
+}
+
+func TestIntegrationNewProducer_Env(t *testing.T) {
+	testutils.Integration(t)
+
+	var tests = []struct {
+		env    string
+		typeOf string
+		opts   func(*streamconfig.Producer)
+	}{
+		{
+			"standardstream",
+			"*standardstreamclient.Producer",
+			nil,
+		},
+
+		{
+			"inmem",
+			"*inmemclient.Producer",
+			nil,
+		},
+
+		{
+			"kafka",
+			"*kafkaclient.Producer",
+			func(c *streamconfig.Producer) {
+				c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+				c.Kafka.Topic = "test"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			os.Setenv("STREAMCLIENT_PRODUCER", tt.env)
+			defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+
+			producer, err := streamclient.NewProducer(tt.opts)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.typeOf, reflect.TypeOf(producer).String())
+		})
+	}
+}
+
+func TestIntegrationNewProducer_Pubsub(t *testing.T) {
+	os.Setenv("STREAMCLIENT_PRODUCER", "pubsub")
+	defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+
+	_, err := streamclient.NewProducer()
+	require.Error(t, err)
+}
+
+func TestIntegrationNewProducer_Env_DryRun(t *testing.T) {
+	os.Setenv("DRY_RUN", "1")
+	defer os.Unsetenv("DRY_RUN")
+
+	producer, err := streamclient.NewProducer()
+	require.NoError(t, err)
+
+	assert.Equal(t, "*standardstreamclient.Producer", reflect.TypeOf(producer).String())
+}
+
+func TestIntegrationNewProducer_Env_DryRun_Overridden(t *testing.T) {
+	os.Setenv("STREAMCLIENT_PRODUCER", "inmem")
+	defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+
+	os.Setenv("DRY_RUN", "1")
+	defer os.Unsetenv("DRY_RUN")
+
+	producer, err := streamclient.NewProducer()
+	require.NoError(t, err)
+
+	assert.Equal(t, "*inmemclient.Producer", reflect.TypeOf(producer).String())
+}
+
+func TestIntegrationNewProducer_Unknown(t *testing.T) {
+	_, err := streamclient.NewProducer()
+	assert.Error(t, err)
+}

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -21,6 +21,10 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 	// After we've defined the default values, we overwrite them with any provided
 	// custom configuration values.
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
 		option(config)
 	}
 
@@ -43,6 +47,10 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 	// After we've defined the default values, we overwrite them with any provided
 	// custom configuration values.
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
 		option(config)
 	}
 

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -31,6 +31,13 @@ func TestNewConsumer(t *testing.T) {
 	}
 }
 
+func TestNewConsumer_Options_Nil(t *testing.T) {
+	t.Parallel()
+
+	_, err := streamconfig.NewConsumer(nil)
+	assert.NoError(t, err)
+}
+
 func TestNewProducer(t *testing.T) {
 	t.Parallel()
 
@@ -51,4 +58,11 @@ func TestNewProducer(t *testing.T) {
 	for _, tt := range tests {
 		assert.Equal(t, tt.expected, reflect.TypeOf(tt.config).String())
 	}
+}
+
+func TestNewProducer_Options_Nil(t *testing.T) {
+	t.Parallel()
+
+	_, err := streamconfig.NewProducer(nil)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
These functions are the main entrypoint into the functionality of this
package.

It is fairly straight forward:

In the case of NewConsumer, if you set the `STREAMCLIENT_CONSUMER`
environment variable to the name of one of the streamclient
implementations, it will return that implementation. Valid names are:

- standardstream
- inmem
- kafka
- pubsub*

If you _don't_ pass in the environment variable, but send data to the
application over Stdin, the "standardstream" consumer will be returned
from this function:

    echo '{"hello": "world" }' | go run main.go

In the case of NewProducer, the same applies as the consumer, except
that the environment variable is named `STREAMCLIENT_PRODUCER`.

Also, there is no concept of Stdin for the producer, but if you set
the environment variable `DRY_RUN` to anything other than an empty
string, the "standardstream" producer will be returned, but _only_ if
the `STREAMCLIENT_PRODUCER` environment variable isn't also set.

In the case of both functions, if the right streamclient implementation
cannot be determined by the provided context, none will be chosen, and an
error will be returned instead.

\* pubsub has yet to be implemented, and will return an error for the time
being.