### PR TITLE
 Move Logger to top-level config object

### DIFF
--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -56,8 +56,8 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.env, func(t *testing.T) {
-			os.Setenv("STREAMCLIENT_CONSUMER", tt.env)
-			defer os.Unsetenv("STREAMCLIENT_CONSUMER")
+			_ = os.Setenv("STREAMCLIENT_CONSUMER", tt.env)
+			defer os.Unsetenv("STREAMCLIENT_CONSUMER") // nolint: errcheck
 
 			consumer, err := streamclient.NewConsumer(tt.opts)
 			require.NoError(t, err)
@@ -68,8 +68,8 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 }
 
 func TestIntegrationNewConsumer_Pubsub(t *testing.T) {
-	os.Setenv("STREAMCLIENT_CONSUMER", "pubsub")
-	defer os.Unsetenv("STREAMCLIENT_CONSUMER")
+	_ = os.Setenv("STREAMCLIENT_CONSUMER", "pubsub")
+	defer os.Unsetenv("STREAMCLIENT_CONSUMER") // nolint: errcheck
 
 	_, err := streamclient.NewConsumer()
 	assert.Error(t, err)
@@ -89,9 +89,10 @@ func TestIntegrationNewConsumer_PipedData(t *testing.T) {
 
 	stdin, err := cmd.StdinPipe()
 	require.NoError(t, err)
-	defer stdin.Close()
+	defer func() { assert.NoError(t, stdin.Close()) }()
 
-	io.WriteString(stdin, `{ "hello": "world" }`)
+	_, err = io.WriteString(stdin, `{ "hello": "world" }`)
+	require.NoError(t, err)
 
 	b, err := cmd.CombinedOutput()
 	if e, ok := err.(*exec.ExitError); ok {

--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"go.uber.org/zap"
 )
 
 // Consumer implements the stream.Consumer interface for the inmem client.
@@ -20,6 +21,7 @@ type Consumer struct {
 	// other consumer implementations, irrelevant to the current implementation.
 	rawConfig streamconfig.Consumer
 
+	logger   *zap.Logger
 	wg       sync.WaitGroup
 	messages chan streammsg.Message
 }
@@ -90,6 +92,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 	consumer := &Consumer{
 		config:    config.Inmem,
 		rawConfig: config,
+		logger:    &config.Logger,
 		messages:  make(chan streammsg.Message),
 	}
 

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"go.uber.org/zap"
 )
 
 // Producer implements the stream.Producer interface for the inmem client.
@@ -20,6 +21,7 @@ type Producer struct {
 	// other producer implementations, irrelevant to the current implementation.
 	rawConfig streamconfig.Producer
 
+	logger   *zap.Logger
 	wg       sync.WaitGroup
 	messages chan<- streammsg.Message
 }
@@ -81,6 +83,7 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 	producer := &Producer{
 		config:    config.Inmem,
 		rawConfig: config,
+		logger:    &config.Logger,
 		messages:  ch,
 	}
 

--- a/streamclient/kafkaclient/eventhandlers.go
+++ b/streamclient/kafkaclient/eventhandlers.go
@@ -34,7 +34,7 @@ const (
 
 // handleAssignedPartitions assigns the consumer to a provided partition.
 func (c *Consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
-	log := c.config.Logger.With(
+	log := c.logger.With(
 		zap.String("eventType", eventAssignedPartitions),
 		zap.String("eventDetails", e.String()),
 	)
@@ -52,7 +52,7 @@ func (c *Consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
 
 // handleRevokedPartitions unassigns the consumer from a provided partition.
 func (c *Consumer) handleRevokedPartitions(e kafka.RevokedPartitions) {
-	log := c.config.Logger.With(
+	log := c.logger.With(
 		zap.String("eventType", eventRevokedPartitions),
 		zap.String("eventDetails", e.String()),
 	)
@@ -96,7 +96,7 @@ func (c *Consumer) handleOffsetCommitted(e kafka.OffsetsCommitted) {
 		return
 	}
 
-	c.config.Logger.Error(
+	c.logger.Error(
 		"OffsetsCommitted event returned error.",
 		zap.String("eventType", eventOffsetsCommitted),
 		zap.String("eventDetails", e.String()),
@@ -107,12 +107,12 @@ func (c *Consumer) handleOffsetCommitted(e kafka.OffsetsCommitted) {
 
 // handleError handles all error events for the consumer.
 func (c *Consumer) handleError(e kafka.Error) {
-	handleError(c.config.Logger, e)
+	handleError(c.logger, e)
 }
 
 // handleError handles all error events for the producer.
 func (p *Producer) handleError(e kafka.Error) {
-	handleError(p.config.Logger, e)
+	handleError(p.logger, e)
 }
 
 // handleError handles all error events for both the producer and consumer. If
@@ -128,7 +128,7 @@ func (p *Producer) handleError(e kafka.Error) {
 //       are also considering adding an `Events()` channel of our own, so
 //       perhaps we don't have to handle this situation ourselves, and the
 //       application can dictate what they want to do in the case of an error.
-func handleError(logger zap.Logger, e kafka.Error) {
+func handleError(logger *zap.Logger, e kafka.Error) {
 	logger.Fatal(
 		"Received event from Kafka.",
 		zap.String("eventType", eventError),
@@ -152,7 +152,7 @@ func (c *Consumer) handleMessage(e *kafka.Message) bool {
 	select {
 	case c.messages <- *msg:
 	case <-c.quit:
-		c.config.Logger.Info("Received quit signal while waiting to deliver " +
+		c.logger.Info("Received quit signal while waiting to deliver " +
 			"Kafka message to messages channel. Exiting consumer.")
 
 		return true
@@ -170,7 +170,7 @@ func (p *Producer) handleMessage(e *kafka.Message) {
 		return
 	}
 
-	p.config.Logger.Error(
+	p.logger.Error(
 		"Received failed message delivery event from Kafka.",
 		zap.String("eventType", eventMessage),
 		zap.String("eventDetails", e.String()),

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -187,7 +187,7 @@ func TestConsumerConfig(tb testing.TB, topicAndGroup string, options ...func(c *
 		require.NoError(tb, err)
 
 		verbose := func(c *streamconfig.Consumer) {
-			c.Kafka.Logger = *logger.Named("TestConsumer")
+			c.Logger = *logger.Named("TestConsumer")
 			c.Kafka.Debug.All = true
 		}
 
@@ -218,7 +218,7 @@ func TestProducerConfig(tb testing.TB, topic string, options ...func(c *streamco
 		require.NoError(tb, err)
 
 		verbose := func(c *streamconfig.Producer) {
-			c.Kafka.Logger = *logger.Named("TestProducer")
+			c.Logger = *logger.Named("TestProducer")
 			c.Kafka.Debug.All = true
 		}
 

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -52,8 +52,8 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.env, func(t *testing.T) {
-			os.Setenv("STREAMCLIENT_PRODUCER", tt.env)
-			defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+			_ = os.Setenv("STREAMCLIENT_PRODUCER", tt.env)
+			defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
 
 			producer, err := streamclient.NewProducer(tt.opts)
 			require.NoError(t, err)
@@ -64,16 +64,16 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 }
 
 func TestIntegrationNewProducer_Pubsub(t *testing.T) {
-	os.Setenv("STREAMCLIENT_PRODUCER", "pubsub")
-	defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+	_ = os.Setenv("STREAMCLIENT_PRODUCER", "pubsub")
+	defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
 
 	_, err := streamclient.NewProducer()
 	require.Error(t, err)
 }
 
 func TestIntegrationNewProducer_Env_DryRun(t *testing.T) {
-	os.Setenv("DRY_RUN", "1")
-	defer os.Unsetenv("DRY_RUN")
+	_ = os.Setenv("DRY_RUN", "1")
+	defer os.Unsetenv("DRY_RUN") // nolint: errcheck
 
 	producer, err := streamclient.NewProducer()
 	require.NoError(t, err)
@@ -82,11 +82,11 @@ func TestIntegrationNewProducer_Env_DryRun(t *testing.T) {
 }
 
 func TestIntegrationNewProducer_Env_DryRun_Overridden(t *testing.T) {
-	os.Setenv("STREAMCLIENT_PRODUCER", "inmem")
-	defer os.Unsetenv("STREAMCLIENT_PRODUCER")
+	_ = os.Setenv("STREAMCLIENT_PRODUCER", "inmem")
+	defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
 
-	os.Setenv("DRY_RUN", "1")
-	defer os.Unsetenv("DRY_RUN")
+	_ = os.Setenv("DRY_RUN", "1")
+	defer os.Unsetenv("DRY_RUN") // nolint: errcheck
 
 	producer, err := streamclient.NewProducer()
 	require.NoError(t, err)

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"go.uber.org/zap"
 )
 
 // maxCapacity represents the maximum number of tokens supported per-line. This
@@ -28,6 +29,7 @@ type Consumer struct {
 	// other consumer implementations, irrelevant to the current implementation.
 	rawConfig streamconfig.Consumer
 
+	logger   *zap.Logger
 	wg       sync.WaitGroup
 	messages chan streammsg.Message
 }
@@ -123,6 +125,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 	consumer := &Consumer{
 		config:    config.Standardstream,
 		rawConfig: config,
+		logger:    &config.Logger,
 		messages:  make(chan streammsg.Message),
 	}
 

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -23,6 +23,7 @@ type Producer struct {
 	// other producer implementations, irrelevant to the current implementation.
 	rawConfig streamconfig.Producer
 
+	logger   *zap.Logger
 	wg       sync.WaitGroup
 	messages chan<- streammsg.Message
 }
@@ -56,7 +57,7 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 
 			_, err := producer.config.Writer.Write(message)
 			if err != nil {
-				producer.config.Logger.Fatal(
+				producer.logger.Fatal(
 					"Unable to write message to stream.",
 					zap.ByteString("messageValue", message),
 					zap.Error(err),
@@ -99,6 +100,7 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 	producer := &Producer{
 		config:    config.Standardstream,
 		rawConfig: config,
+		logger:    &config.Logger,
 		messages:  ch,
 	}
 

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"go.uber.org/zap"
 )
 
 // Consumer contains the configuration for all the different consumer that
@@ -17,6 +18,10 @@ type Consumer struct {
 	Kafka          kafkaconfig.Consumer
 	Pubsub         pubsubconfig.Consumer
 	Standardstream standardstreamconfig.Consumer
+
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a no-op logger will be used.
+	Logger zap.Logger
 }
 
 // Producer contains the configuration for all the different consumer that
@@ -29,4 +34,18 @@ type Producer struct {
 	Kafka          kafkaconfig.Producer
 	Pubsub         pubsubconfig.Producer
 	Standardstream standardstreamconfig.Producer
+
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a no-op logger will be used.
+	Logger zap.Logger
+}
+
+// ConsumerDefaults holds the default values for Consumer.
+var ConsumerDefaults = Consumer{
+	Logger: *zap.NewNop(),
+}
+
+// ProducerDefaults holds the default values for Producer.
+var ProducerDefaults = Producer{
+	Logger: *zap.NewNop(),
 }

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -1,19 +1,54 @@
 package streamconfig_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	t.Parallel()
 
-	_ = streamconfig.Consumer{}
+	_ = streamconfig.Consumer{
+		Inmem:          inmemconfig.Consumer{},
+		Kafka:          kafkaconfig.Consumer{},
+		Pubsub:         pubsubconfig.Consumer{},
+		Standardstream: standardstreamconfig.Consumer{},
+		Logger:         *zap.NewNop(),
+	}
+}
+
+func TestConsumerDefaults(t *testing.T) {
+	t.Parallel()
+
+	config := streamconfig.ConsumerDefaults
+
+	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 }
 
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
-	_ = streamconfig.Producer{}
+	_ = streamconfig.Producer{
+		Inmem:          inmemconfig.Producer{},
+		Kafka:          kafkaconfig.Producer{},
+		Pubsub:         pubsubconfig.Producer{},
+		Standardstream: standardstreamconfig.Producer{},
+		Logger:         *zap.NewNop(),
+	}
+}
+
+func TestProducerDefaults(t *testing.T) {
+	t.Parallel()
+
+	config := streamconfig.ProducerDefaults
+
+	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 }

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -11,12 +11,13 @@ import (
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
 func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
-	config := &Consumer{
-		Inmem:          inmemconfig.ConsumerDefaults,
-		Kafka:          kafkaconfig.ConsumerDefaults,
-		Pubsub:         pubsubconfig.ConsumerDefaults,
-		Standardstream: standardstreamconfig.ConsumerDefaults,
-	}
+	defaults := ConsumerDefaults
+
+	config := &defaults
+	config.Inmem = inmemconfig.ConsumerDefaults
+	config.Kafka = kafkaconfig.ConsumerDefaults
+	config.Pubsub = pubsubconfig.ConsumerDefaults
+	config.Standardstream = standardstreamconfig.ConsumerDefaults
 
 	// After we've defined the default values, we overwrite them with any provided
 	// custom configuration values.
@@ -37,12 +38,13 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
 func NewProducer(options ...func(*Producer)) (Producer, error) {
-	config := &Producer{
-		Inmem:          inmemconfig.ProducerDefaults,
-		Kafka:          kafkaconfig.ProducerDefaults,
-		Pubsub:         pubsubconfig.ProducerDefaults,
-		Standardstream: standardstreamconfig.ProducerDefaults,
-	}
+	defaults := ProducerDefaults
+
+	config := &defaults
+	config.Inmem = inmemconfig.ProducerDefaults
+	config.Kafka = kafkaconfig.ProducerDefaults
+	config.Pubsub = pubsubconfig.ProducerDefaults
+	config.Standardstream = standardstreamconfig.ProducerDefaults
 
 	// After we've defined the default values, we overwrite them with any provided
 	// custom configuration values.

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -24,6 +24,7 @@ func TestNewConsumer(t *testing.T) {
 		{"kafkaconfig.Consumer", config.Kafka},
 		{"pubsubconfig.Consumer", config.Pubsub},
 		{"standardstreamconfig.Consumer", config.Standardstream},
+		{"zap.Logger", config.Logger},
 	}
 
 	for _, tt := range tests {
@@ -53,6 +54,7 @@ func TestNewProducer(t *testing.T) {
 		{"kafkaconfig.Producer", config.Kafka},
 		{"pubsubconfig.Producer", config.Pubsub},
 		{"standardstreamconfig.Producer", config.Standardstream},
+		{"zap.Logger", config.Logger},
 	}
 
 	for _, tt := range tests {

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -2,16 +2,11 @@ package inmemconfig
 
 import (
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
-	"go.uber.org/zap"
 )
 
 // Consumer is a value-object, containing all user-configurable configuration
 // values that dictate how the inmem client's consumer will behave.
 type Consumer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
-
 	// Store is the inmem store from which to consume messages. If left undefined,
 	// an internal store will be used.
 	Store *inmemstore.Store
@@ -19,6 +14,5 @@ type Consumer struct {
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	Logger: *zap.NewNop(),
-	Store:  inmemstore.New(),
+	Store: inmemstore.New(),
 }

--- a/streamconfig/inmemconfig/consumer_test.go
+++ b/streamconfig/inmemconfig/consumer_test.go
@@ -7,15 +7,13 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	t.Parallel()
 
 	_ = inmemconfig.Consumer{
-		Logger: *zap.NewNop(),
-		Store:  inmemstore.New(),
+		Store: inmemstore.New(),
 	}
 }
 
@@ -24,6 +22,5 @@ func TestConsumerDefaults(t *testing.T) {
 
 	config := inmemconfig.ConsumerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.Equal(t, "*inmemstore.Store", reflect.TypeOf(config.Store).String())
 }

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -2,16 +2,11 @@ package inmemconfig
 
 import (
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
-	"go.uber.org/zap"
 )
 
 // Producer is a value-object, containing all user-configurable configuration
 // values that dictate how the inmem client's producer will behave.
 type Producer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
-
 	// Store is the inmem store to which to produce messages. If left undefined,
 	// an internal store will be used.
 	Store *inmemstore.Store
@@ -19,6 +14,5 @@ type Producer struct {
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
-	Logger: *zap.NewNop(),
-	Store:  inmemstore.New(),
+	Store: inmemstore.New(),
 }

--- a/streamconfig/inmemconfig/producer_test.go
+++ b/streamconfig/inmemconfig/producer_test.go
@@ -7,15 +7,13 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
 	_ = inmemconfig.Producer{
-		Logger: *zap.NewNop(),
-		Store:  inmemstore.New(),
+		Store: inmemstore.New(),
 	}
 }
 
@@ -24,6 +22,5 @@ func TestProducerDefaults(t *testing.T) {
 
 	config := inmemconfig.ProducerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.Equal(t, "*inmemstore.Store", reflect.TypeOf(config.Store).String())
 }

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
-	"go.uber.org/zap"
 )
 
 // Consumer is a value-object, containing all user-configurable configuration
@@ -58,10 +57,6 @@ type Consumer struct {
 	// * none: throw exception to the consumer if no previous offset is found for
 	//   the consumer's group
 	InitialOffset Offset `kafka:"{topic}.auto.offset.reset,omitempty"`
-
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger `kafka:"-"`
 
 	// SecurityProtocol is the protocol used to communicate with brokers.
 	SecurityProtocol Protocol `kafka:"security.protocol,omitempty"`
@@ -145,7 +140,6 @@ var ConsumerDefaults = Consumer{
 	Debug:             Debug{},
 	HeartbeatInterval: 10 * time.Second,
 	InitialOffset:     OffsetBeginning,
-	Logger:            *zap.NewNop(),
 	SecurityProtocol:  ProtocolPlaintext,
 	SessionTimeout:    30 * time.Second,
 	SSL:               SSL{},

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -1,7 +1,6 @@
 package kafkaconfig_test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 var consumerDefaults = map[string]interface{}{
@@ -31,7 +29,6 @@ func TestConsumer(t *testing.T) {
 		HeartbeatInterval: time.Duration(0),
 		ID:                "",
 		InitialOffset:     kafkaconfig.OffsetBeginning,
-		Logger:            *zap.NewNop(),
 		SecurityProtocol:  kafkaconfig.ProtocolPlaintext,
 		SessionTimeout:    time.Duration(0),
 		SSL:               kafkaconfig.SSL{KeyPath: ""},
@@ -48,7 +45,6 @@ func TestConsumerDefaults(t *testing.T) {
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, 10*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, kafkaconfig.OffsetBeginning, config.InitialOffset)
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
 }
@@ -148,11 +144,6 @@ func TestConsumer_ConfigMap(t *testing.T) {
 		"initialOffset (beginning)": {
 			&kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetBeginning},
 			&kafka.ConfigMap{"default.topic.config": kafka.ConfigMap{"auto.offset.reset": "beginning"}},
-		},
-
-		"logger (skipped)": {
-			&kafkaconfig.Consumer{Logger: *zap.NewNop()},
-			&kafka.ConfigMap{},
 		},
 
 		"securityProtocol (plaintext)": {

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
-	"go.uber.org/zap"
 )
 
 // Producer is a value-object, containing all user-configurable configuration
@@ -38,10 +37,6 @@ type Producer struct {
 	// by allowing a logical application name to be included in server-side
 	// request logging.
 	ID string `kafka:"client.id,omitempty"`
-
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
 
 	// MaxDeliveryRetries dictates how many times to retry sending a failing
 	// MessageSet. Note: retrying may cause reordering. Defaults to 0 retries to
@@ -123,7 +118,6 @@ type staticProducer struct {
 var ProducerDefaults = Producer{
 	Debug:                  Debug{},
 	HeartbeatInterval:      10 * time.Second,
-	Logger:                 *zap.NewNop(),
 	MaxDeliveryRetries:     0,
 	MaxQueueBufferDuration: time.Duration(0),
 	MaxQueueSizeKBytes:     2097151,

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -1,7 +1,6 @@
 package kafkaconfig_test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 var producerDefaults = map[string]interface{}{
@@ -31,7 +29,6 @@ func TestProducer(t *testing.T) {
 		Debug:                  kafkaconfig.Debug{All: true},
 		HeartbeatInterval:      time.Duration(0),
 		ID:                     "",
-		Logger:                 *zap.NewNop(),
 		MaxDeliveryRetries:     0,
 		MaxQueueBufferDuration: time.Duration(0),
 		MaxQueueSizeKBytes:     0,
@@ -51,7 +48,6 @@ func TestProducerDefaults(t *testing.T) {
 
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, 10*time.Second, config.HeartbeatInterval)
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.Equal(t, 0, config.MaxDeliveryRetries)
 	assert.Equal(t, 0*time.Second, config.MaxQueueBufferDuration)
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)
@@ -120,11 +116,6 @@ func TestProducer_ConfigMap(t *testing.T) {
 
 		"ID (empty)": {
 			&kafkaconfig.Producer{ID: ""},
-			&kafka.ConfigMap{},
-		},
-
-		"logger (skipped)": {
-			&kafkaconfig.Producer{Logger: *zap.NewNop()},
 			&kafka.ConfigMap{},
 		},
 

--- a/streamconfig/pubsubconfig/consumer.go
+++ b/streamconfig/pubsubconfig/consumer.go
@@ -1,16 +1,9 @@
 package pubsubconfig
 
-import "go.uber.org/zap"
-
 // Consumer is a value-type, containing all user-configurable configuration
 // values that dictate how a Pubsub client's consumer will behave.
 type Consumer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
 }
 
 // ConsumerDefaults holds the default values for Consumer.
-var ConsumerDefaults = Consumer{
-	Logger: *zap.NewNop(),
-}
+var ConsumerDefaults = Consumer{}

--- a/streamconfig/pubsubconfig/consumer_test.go
+++ b/streamconfig/pubsubconfig/consumer_test.go
@@ -1,26 +1,13 @@
 package pubsubconfig_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	t.Parallel()
 
-	_ = pubsubconfig.Consumer{
-		Logger: *zap.NewNop(),
-	}
-}
-
-func TestConsumerDefaults(t *testing.T) {
-	t.Parallel()
-
-	config := pubsubconfig.ConsumerDefaults
-
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	_ = pubsubconfig.Consumer{}
 }

--- a/streamconfig/pubsubconfig/producer.go
+++ b/streamconfig/pubsubconfig/producer.go
@@ -1,16 +1,9 @@
 package pubsubconfig
 
-import "go.uber.org/zap"
-
 // Producer is a value-type, containing all user-configurable configuration
 // values that dictate how a Pubsub client's producer will behave.
 type Producer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
 }
 
 // ProducerDefaults holds the default values for Producer.
-var ProducerDefaults = Producer{
-	Logger: *zap.NewNop(),
-}
+var ProducerDefaults = Producer{}

--- a/streamconfig/pubsubconfig/producer_test.go
+++ b/streamconfig/pubsubconfig/producer_test.go
@@ -1,26 +1,13 @@
 package pubsubconfig_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
-	_ = pubsubconfig.Producer{
-		Logger: *zap.NewNop(),
-	}
-}
-
-func TestProducerDefaults(t *testing.T) {
-	t.Parallel()
-
-	config := pubsubconfig.ProducerDefaults
-
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	_ = pubsubconfig.Producer{}
 }

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -3,17 +3,11 @@ package standardstreamconfig
 import (
 	"io"
 	"os"
-
-	"go.uber.org/zap"
 )
 
 // Consumer is a value-object, containing all user-configurable configuration
 // values that dictate how the standard stream client's consumer will behave.
 type Consumer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
-
 	// Reader is the object that implements the io.ReadCloser interface
 	// (io.Reader + io.Closer). This object is used to read messages from the
 	// stream. Defaults to `os.Stdin`.
@@ -22,6 +16,5 @@ type Consumer struct {
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	Logger: *zap.NewNop(),
 	Reader: os.Stdin,
 }

--- a/streamconfig/standardstreamconfig/consumer_test.go
+++ b/streamconfig/standardstreamconfig/consumer_test.go
@@ -2,19 +2,16 @@ package standardstreamconfig_test
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
 	t.Parallel()
 
 	_ = standardstreamconfig.Consumer{
-		Logger: *zap.NewNop(),
 		Reader: os.Stdin,
 	}
 }
@@ -24,6 +21,5 @@ func TestConsumerDefaults(t *testing.T) {
 
 	config := standardstreamconfig.ConsumerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.EqualValues(t, os.Stdin, config.Reader)
 }

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -3,17 +3,11 @@ package standardstreamconfig
 import (
 	"io"
 	"os"
-
-	"go.uber.org/zap"
 )
 
 // Producer is a value-object, containing all user-configurable configuration
 // values that dictate how the standard stream client's producer will behave.
 type Producer struct {
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger
-
 	// Writer is the object that implements the io.Writer interface. This object
 	// is used to write new messages to the stream. Defaults to `os.Stdout`.
 	Writer io.Writer
@@ -21,6 +15,5 @@ type Producer struct {
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
-	Logger: *zap.NewNop(),
 	Writer: os.Stdout,
 }

--- a/streamconfig/standardstreamconfig/producer_test.go
+++ b/streamconfig/standardstreamconfig/producer_test.go
@@ -2,19 +2,16 @@ package standardstreamconfig_test
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
 	_ = standardstreamconfig.Producer{
-		Logger: *zap.NewNop(),
 		Writer: os.Stdout,
 	}
 }
@@ -24,6 +21,5 @@ func TestProducerDefaults(t *testing.T) {
 
 	config := standardstreamconfig.ProducerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.EqualValues(t, os.Stdout, config.Writer)
 }

--- a/streamutils/interrupt.go
+++ b/streamutils/interrupt.go
@@ -12,7 +12,7 @@ import (
 // closer function once received. It has a built-in timeout capability to force
 // terminate the application when the closer takes too long to close, or returns
 // an error during closing.
-func HandleInterrupts(closer func() error, logger zap.Logger) {
+func HandleInterrupts(closer func() error, logger *zap.Logger) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
 


### PR DESCRIPTION
No more this:

```golang
options := func(c *streamconfig.Consumer) {
  c.Inmem.Logger = *zap.NewNop()
  c.Kafka.Logger = *zap.NewNop()
  c.Standardstream.Logger = *zap.NewNop()
  c.Pubsub.Logger = *zap.NewNop()
}
```

But this:

```golang
options := func(c *streamconfig.Consumer) {
  c.Logger = *zap.NewNop()
}
```