### PR TITLE
Readability & usability improvements

### DIFF
--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
 )
 
@@ -49,6 +50,17 @@ func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, erro
 			consumer.messages <- msg
 		}
 	}()
+
+	// Finally, we monitor for any interrupt signals. Ideally, the user handles
+	// these cases gracefully, but just in case, we try to close the consumer if
+	// any such interrupt signal is intercepted. If closing the consumer fails, we
+	// exit 1, and log a fatal message explaining what happened.
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag.
+	if consumer.rawConfig.HandleInterrupt {
+		go streamutils.HandleInterrupts(consumer.Close, consumer.logger)
+	}
 
 	return consumer, nil
 }

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
 )
 
@@ -48,6 +49,17 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 			producer.config.Store.Add(msg)
 		}
 	}()
+
+	// Finally, we monitor for any interrupt signals. Ideally, the user handles
+	// these cases gracefully, but just in case, we try to close the producer if
+	// any such interrupt signal is intercepted. If closing the producer fails, we
+	// exit 1, and log a fatal message explaining what happened.
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag.
+	if producer.rawConfig.HandleInterrupt {
+		go streamutils.HandleInterrupts(producer.Close, producer.logger)
+	}
 
 	return producer, nil
 }

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -59,7 +59,12 @@ func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, erro
 	// these cases gracefully, but just in case, we try to close the consumer if
 	// any such interrupt signal is intercepted. If closing the consumer fails, we
 	// exit 1, and log a fatal message explaining what happened.
-	go streamutils.HandleInterrupts(consumer.Close, consumer.logger)
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag.
+	if consumer.rawConfig.HandleInterrupt {
+		go streamutils.HandleInterrupts(consumer.Close, consumer.logger)
+	}
 
 	return consumer, nil
 }

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
@@ -15,14 +14,9 @@ import (
 
 // Producer implements the stream.Producer interface for the Kafka client.
 type Producer struct {
-	// config represents the relevant portion of the configuration passed into the
-	// producer its initialization function.
-	config kafkaconfig.Producer
-
-	// rawConfig represents the as-is configuration passed into the producer its
-	// initialization function by the user. This includes the configuration of
-	// other producer implementations, irrelevant to the current implementation.
-	rawConfig streamconfig.Producer
+	// c represents the configuration passed into the producer on
+	// initialization.
+	c streamconfig.Producer
 
 	logger   *zap.Logger
 	kafka    *kafka.Producer
@@ -70,7 +64,7 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	//
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
-	if producer.rawConfig.HandleInterrupt {
+	if producer.c.HandleInterrupt {
 		go streamutils.HandleInterrupts(producer.Close, producer.logger)
 	}
 
@@ -122,7 +116,7 @@ func (p *Producer) Close() (err error) {
 
 // Config returns a read-only representation of the producer configuration.
 func (p *Producer) Config() streamconfig.Producer {
-	return p.rawConfig
+	return p.c
 }
 
 func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Producer)) (*Producer, error) {
@@ -147,13 +141,12 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 	}
 
 	producer := &Producer{
-		config:    config.Kafka,
-		rawConfig: config,
-		logger:    &config.Logger,
-		kafka:     kafkaproducer,
-		messages:  ch,
-		quit:      make(chan bool),
-		once:      &sync.Once{},
+		c:        config,
+		logger:   &config.Logger,
+		kafka:    kafkaproducer,
+		messages: ch,
+		quit:     make(chan bool),
+		once:     &sync.Once{},
 	}
 
 	return producer, nil
@@ -217,7 +210,7 @@ func (p *Producer) newMessage(m streammsg.Message) *kafka.Message {
 // determine in which partition the message should end up, based on the key set
 // for the message.
 func (p *Producer) newToppar(m streammsg.Message) kafka.TopicPartition {
-	topic := &p.config.Topic
+	topic := &p.c.Kafka.Topic
 	if m.Topic != "" {
 		topic = &m.Topic
 	}

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -67,7 +67,12 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	// these cases gracefully, but just in case, we try to close the producer if
 	// any such interrupt signal is intercepted. If closing the producer fails, we
 	// exit 1, and log a fatal message explaining what happened.
-	go streamutils.HandleInterrupts(producer.Close, producer.logger)
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag.
+	if producer.rawConfig.HandleInterrupt {
+		go streamutils.HandleInterrupts(producer.Close, producer.logger)
+	}
 
 	return producer, nil
 }

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
@@ -21,14 +20,9 @@ const maxCapacity = 512 * 1024
 // Consumer implements the stream.Consumer interface for the standard stream
 // client.
 type Consumer struct {
-	// config represents the relevant portion of the configuration passed into the
-	// consumer its initialization function.
-	config standardstreamconfig.Consumer
-
-	// rawConfig represents the as-is configuration passed into the consumer its
-	// initialization function by the user. This includes the configuration of
-	// other consumer implementations, irrelevant to the current implementation.
-	rawConfig streamconfig.Consumer
+	// c represents the configuration passed into the consumer on
+	// initialization.
+	c streamconfig.Consumer
 
 	logger   *zap.Logger
 	wg       sync.WaitGroup
@@ -61,7 +55,7 @@ func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, erro
 	//
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
-	if consumer.rawConfig.HandleInterrupt {
+	if consumer.c.HandleInterrupt {
 		go streamutils.HandleInterrupts(consumer.Close, consumer.logger)
 	}
 
@@ -86,7 +80,7 @@ func (c *Consumer) Nack(_ streammsg.Message) error {
 
 // Close closes the consumer connection.
 func (c *Consumer) Close() error {
-	err := c.config.Reader.Close()
+	err := c.c.Standardstream.Reader.Close()
 	if err != nil {
 		return err
 	}
@@ -100,7 +94,7 @@ func (c *Consumer) Close() error {
 
 // Config returns a read-only representation of the consumer configuration.
 func (c *Consumer) Config() streamconfig.Consumer {
-	return c.rawConfig
+	return c.c
 }
 
 func (c *Consumer) consume() {
@@ -114,7 +108,7 @@ func (c *Consumer) consume() {
 		c.wg.Done()
 	}()
 
-	scanner := bufio.NewScanner(c.config.Reader)
+	scanner := bufio.NewScanner(c.c.Standardstream.Reader)
 	buf := make([]byte, 0, maxCapacity)
 	scanner.Buffer(buf, maxCapacity)
 
@@ -141,10 +135,9 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 	}
 
 	consumer := &Consumer{
-		config:    config.Standardstream,
-		rawConfig: config,
-		logger:    &config.Logger,
-		messages:  make(chan streammsg.Message),
+		c:        config,
+		logger:   &config.Logger,
+		messages: make(chan streammsg.Message),
 	}
 
 	return consumer, nil

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
 )
 
@@ -65,6 +66,17 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 			}
 		}
 	}()
+
+	// Finally, we monitor for any interrupt signals. Ideally, the user handles
+	// these cases gracefully, but just in case, we try to close the producer if
+	// any such interrupt signal is intercepted. If closing the producer fails, we
+	// exit 1, and log a fatal message explaining what happened.
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag.
+	if producer.rawConfig.HandleInterrupt {
+		go streamutils.HandleInterrupts(producer.Close, producer.logger)
+	}
 
 	return producer, nil
 }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -22,6 +22,12 @@ type Consumer struct {
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
 	Logger zap.Logger
+
+	// HandleInterrupt determines whether the consumer should close itself
+	// gracefully when an interrupt signal (^C) is received. This defaults to true
+	// to increase first-time ease-of-use, but if the application wants to handle
+	// these signals manually, this flag disable the automated implementation.
+	HandleInterrupt bool
 }
 
 // Producer contains the configuration for all the different consumer that
@@ -38,14 +44,22 @@ type Producer struct {
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
 	Logger zap.Logger
+
+	// HandleInterrupt determines whether the producer should close itself
+	// gracefully when an interrupt signal (^C) is received. This defaults to true
+	// to increase first-time ease-of-use, but if the application wants to handle
+	// these signals manually, this flag disable the automated implementation.
+	HandleInterrupt bool
 }
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	Logger: *zap.NewNop(),
+	Logger:          *zap.NewNop(),
+	HandleInterrupt: true,
 }
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
-	Logger: *zap.NewNop(),
+	Logger:          *zap.NewNop(),
+	HandleInterrupt: true,
 }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -26,7 +26,7 @@ type Consumer struct {
 	// HandleInterrupt determines whether the consumer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
-	// these signals manually, this flag disable the automated implementation.
+	// these signals manually, this flag disables the automated implementation.
 	HandleInterrupt bool
 }
 
@@ -48,7 +48,7 @@ type Producer struct {
 	// HandleInterrupt determines whether the producer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
-	// these signals manually, this flag disable the automated implementation.
+	// these signals manually, this flag disables the automated implementation.
 	HandleInterrupt bool
 }
 

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -17,11 +17,12 @@ func TestConsumer(t *testing.T) {
 	t.Parallel()
 
 	_ = streamconfig.Consumer{
-		Inmem:          inmemconfig.Consumer{},
-		Kafka:          kafkaconfig.Consumer{},
-		Pubsub:         pubsubconfig.Consumer{},
-		Standardstream: standardstreamconfig.Consumer{},
-		Logger:         *zap.NewNop(),
+		Inmem:           inmemconfig.Consumer{},
+		Kafka:           kafkaconfig.Consumer{},
+		Pubsub:          pubsubconfig.Consumer{},
+		Standardstream:  standardstreamconfig.Consumer{},
+		Logger:          *zap.NewNop(),
+		HandleInterrupt: false,
 	}
 }
 
@@ -31,17 +32,19 @@ func TestConsumerDefaults(t *testing.T) {
 	config := streamconfig.ConsumerDefaults
 
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	assert.True(t, config.HandleInterrupt)
 }
 
 func TestProducer(t *testing.T) {
 	t.Parallel()
 
 	_ = streamconfig.Producer{
-		Inmem:          inmemconfig.Producer{},
-		Kafka:          kafkaconfig.Producer{},
-		Pubsub:         pubsubconfig.Producer{},
-		Standardstream: standardstreamconfig.Producer{},
-		Logger:         *zap.NewNop(),
+		Inmem:           inmemconfig.Producer{},
+		Kafka:           kafkaconfig.Producer{},
+		Pubsub:          pubsubconfig.Producer{},
+		Standardstream:  standardstreamconfig.Producer{},
+		Logger:          *zap.NewNop(),
+		HandleInterrupt: false,
 	}
 }
 
@@ -51,4 +54,5 @@ func TestProducerDefaults(t *testing.T) {
 	config := streamconfig.ProducerDefaults
 
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	assert.True(t, config.HandleInterrupt)
 }


### PR DESCRIPTION
- [x] Make Interrupt handling configurable
- [x] Also handle interrutps for inmem and standardstream clients
- [x] Extract all produce and consume logic into their own methods
- [x] Remove concept of "rawConfig" in favor of single object