### PR TITLE
Allow configuring stream clients using environment variables

### DIFF
--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -1,10 +1,14 @@
 package streamconfig
 
 import (
+	"bytes"
+	"text/tabwriter"
+
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 )
 
@@ -21,13 +25,21 @@ type Consumer struct {
 
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
-	Logger zap.Logger
+	Logger zap.Logger `ignored:"true"`
 
 	// HandleInterrupt determines whether the consumer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
 	// these signals manually, this flag disables the automated implementation.
-	HandleInterrupt bool
+	HandleInterrupt bool `ignored:"true"`
+
+	// Name is the name of the current processor. It is currently only used to
+	// determine the prefix for environment-variable based configuration values.
+	// For example, if Name is set to `MyProcessor`, then all environment
+	// variable-based configurations need to start with `MYPROCESSOR_`. If no name
+	// is set, then the prefix is "consumer" is used, so you prepend all
+	// environment variables with "CONSUMER_.
+	Name string `ignored:"true"`
 }
 
 // Producer contains the configuration for all the different consumer that
@@ -43,23 +55,70 @@ type Producer struct {
 
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
-	Logger zap.Logger
+	Logger zap.Logger `ignored:"true"`
 
 	// HandleInterrupt determines whether the producer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
 	// these signals manually, this flag disables the automated implementation.
-	HandleInterrupt bool
+	HandleInterrupt bool `ignored:"true"`
+
+	// Name is the name of the current processor. It is currently only used to
+	// determine the prefix for environment-variable based configuration values.
+	// For example, if Name is set to `MyProcessor`, then all environment
+	// variable-based configurations need to start with `MYPROCESSOR_`.If no name
+	// is set, then the prefix is "producer" is used, so you prepend all
+	// environment variables with "PRODUCER_.
+	Name string `ignored:"true"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
 	Logger:          *zap.NewNop(),
 	HandleInterrupt: true,
+	Name:            "consumer",
 }
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
 	Logger:          *zap.NewNop(),
 	HandleInterrupt: true,
+	Name:            "producer",
+}
+
+// Usage calls the usage() function and returns a byte array.
+func (c Consumer) Usage() []byte {
+	return usage(c.Name, c)
+}
+
+// Usage calls the usage() function and returns a byte array.
+func (p Producer) Usage() []byte {
+	return usage(p.Name, p)
+}
+
+// usage returns a byte array with a table-based explanation on how to set the
+// configuration values using environment variables. This can be used to explain
+// usage details to the user of the application.
+func usage(name string, inf interface{}) []byte {
+	var err error
+	b := &bytes.Buffer{}
+	tabs := tabwriter.NewWriter(b, 1, 0, 4, ' ', 0)
+
+	if c, ok := inf.(Consumer); ok {
+		err = envconfig.Usagef(name, &c, tabs, envconfig.DefaultTableFormat)
+	}
+
+	if p, ok := inf.(Producer); ok {
+		err = envconfig.Usagef(name, &p, tabs, envconfig.DefaultTableFormat)
+	}
+
+	if err != nil {
+		return nil
+	}
+
+	if tabs.Flush() != nil {
+		return nil
+	}
+
+	return b.Bytes()
 }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -40,6 +40,12 @@ type Consumer struct {
 	// is set, then the prefix is "consumer" is used, so you prepend all
 	// environment variables with "CONSUMER_.
 	Name string `ignored:"true"`
+
+	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
+	// stream client based on predefined environment variables. This is enabled by
+	// default, but can be disabled if you want full control over the behavior of
+	// the stream client without any outside influence.
+	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 }
 
 // Producer contains the configuration for all the different consumer that
@@ -70,6 +76,12 @@ type Producer struct {
 	// is set, then the prefix is "producer" is used, so you prepend all
 	// environment variables with "PRODUCER_.
 	Name string `ignored:"true"`
+
+	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
+	// stream client based on predefined environment variables. This is enabled by
+	// default, but can be disabled if you want full control over the behavior of
+	// the stream client without any outside influence.
+	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.
@@ -77,6 +89,7 @@ var ConsumerDefaults = Consumer{
 	Logger:          *zap.NewNop(),
 	HandleInterrupt: true,
 	Name:            "consumer",
+	AllowEnvironmentBasedConfiguration: true,
 }
 
 // ProducerDefaults holds the default values for Producer.
@@ -84,6 +97,7 @@ var ProducerDefaults = Producer{
 	Logger:          *zap.NewNop(),
 	HandleInterrupt: true,
 	Name:            "producer",
+	AllowEnvironmentBasedConfiguration: true,
 }
 
 // Usage calls the usage() function and returns a byte array.

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -1,8 +1,10 @@
 package streamconfig_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
@@ -10,6 +12,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -23,6 +26,7 @@ func TestConsumer(t *testing.T) {
 		Standardstream:  standardstreamconfig.Consumer{},
 		Logger:          *zap.NewNop(),
 		HandleInterrupt: false,
+		Name:            "",
 	}
 }
 
@@ -33,6 +37,241 @@ func TestConsumerDefaults(t *testing.T) {
 
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
+	assert.Equal(t, "consumer", config.Name)
+}
+
+func TestConsumerUsage(t *testing.T) {
+	c := streamconfig.Consumer{Name: "test_config"}
+	usage := c.Usage()
+
+	assert.Contains(t, string(usage), "TEST_CONFIG_KAFKA_GROUP_ID")
+}
+
+func TestConsumerEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		envs   map[string]string
+		config streamconfig.Consumer
+	}{
+		"Kafka.Brokers": {
+			map[string]string{"CONSUMER_KAFKA_BROKERS": "hello,world"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Brokers: []string{"hello", "world"}}},
+		},
+
+		"Kafka.CommitInterval": {
+			map[string]string{"CONSUMER_KAFKA_COMMIT_INTERVAL": "10ms"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{CommitInterval: 10 * time.Millisecond}},
+		},
+
+		"Kafka.Debug (single)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "broker"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{Broker: true}}},
+		},
+
+		"Kafka.Debug (all)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "all"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (true)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "true"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (1)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "1"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (capitalized)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "All"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (multiple)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "broker,fetch"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{Broker: true, Fetch: true}},
+			},
+		},
+
+		"Kafka.Debug (invalid)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": "nope"},
+			streamconfig.Consumer{},
+		},
+
+		"Kafka.Debug (empty)": {
+			map[string]string{"CONSUMER_KAFKA_DEBUG": ""},
+			streamconfig.Consumer{},
+		},
+
+		"Kafka.GroupID": {
+			map[string]string{"CONSUMER_KAFKA_GROUP_ID": "hello"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{GroupID: "hello"}},
+		},
+
+		"Kafka.HeartbeatInterval": {
+			map[string]string{"CONSUMER_KAFKA_HEARTBEAT_INTERVAL": "5s"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{HeartbeatInterval: 5 * time.Second}},
+		},
+
+		"Kafka.ID": {
+			map[string]string{"CONSUMER_KAFKA_CLIENT_ID": "hi!"},
+			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{ID: "hi!"}},
+		},
+
+		"Kafka.InitialOffset (beginning)": {
+			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "beginning"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetBeginning},
+			},
+		},
+
+		"Kafka.InitialOffset (end)": {
+			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "end"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+			},
+		},
+
+		"Kafka.InitialOffset (capitalized)": {
+			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "End"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+			},
+		},
+
+		"Kafka.SecurityProtocol (plaintext)": {
+			map[string]string{"CONSUMER_KAFKA_SECURITY_PROTOCOL": "plaintext"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SecurityProtocol: kafkaconfig.ProtocolPlaintext},
+			},
+		},
+
+		"Kafka.SecurityProtocol (ssl)": {
+			map[string]string{"CONSUMER_KAFKA_SECURITY_PROTOCOL": "SSL"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SecurityProtocol: kafkaconfig.ProtocolSSL},
+			},
+		},
+
+		"Kafka.SecurityProtocol (sasl_plaintext)": {
+			map[string]string{"CONSUMER_KAFKA_SECURITY_PROTOCOL": "sasl_plaintext"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SecurityProtocol: kafkaconfig.ProtocolSASLPlaintext},
+			},
+		},
+
+		"Kafka.SecurityProtocol (sasl_ssl)": {
+			map[string]string{"CONSUMER_KAFKA_SECURITY_PROTOCOL": "sasl_ssl"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SecurityProtocol: kafkaconfig.ProtocolSASLSSL},
+			},
+		},
+
+		"Kafka.SessionTimeout": {
+			map[string]string{"CONSUMER_KAFKA_SESSION_TIMEOUT": "1h"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SessionTimeout: 1 * time.Hour},
+			},
+		},
+
+		"Kafka.SSL.CAPath": {
+			map[string]string{"CONSUMER_KAFKA_SSL_CA_PATH": "/tmp"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{CAPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.CertPath": {
+			map[string]string{"CONSUMER_KAFKA_SSL_CERT_PATH": "/tmp"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{CertPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.CRLPath": {
+			map[string]string{"CONSUMER_KAFKA_SSL_CRL_PATH": "/tmp"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{CRLPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.KeyPassword": {
+			map[string]string{"CONSUMER_KAFKA_SSL_KEY_PASSWORD": "1234"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{KeyPassword: "1234"}},
+			},
+		},
+
+		"Kafka.SSL.KeyPath": {
+			map[string]string{"CONSUMER_KAFKA_SSL_KEY_PATH": "/tmp"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{KeyPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.KeystorePassword": {
+			map[string]string{"CONSUMER_KAFKA_SSL_KEYSTORE_PASSWORD": "1234"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{KeystorePassword: "1234"}},
+			},
+		},
+
+		"Kafka.SSL.KeystorePath": {
+			map[string]string{"CONSUMER_KAFKA_SSL_KEYSTORE_PATH": "/tmp"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SSL: kafkaconfig.SSL{KeystorePath: "/tmp"}},
+			},
+		},
+
+		"Kafka.Topics (single)": {
+			map[string]string{"CONSUMER_KAFKA_TOPICS": "hello"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{"hello"}},
+			},
+		},
+
+		"Kafka.Topics (multiple)": {
+			map[string]string{"CONSUMER_KAFKA_TOPICS": "hello,world"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{"hello", "world"}},
+			},
+		},
+
+		// FIXME: we should probably disallow this
+		"Kafka.Topics (none)": {
+			map[string]string{"CONSUMER_KAFKA_TOPICS": ""},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{""}},
+			},
+		},
+
+		// FIXME: we should probably disallow this
+		"Kafka.Topics (empty)": {
+			map[string]string{"CONSUMER_KAFKA_TOPICS": ",,"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{"", "", ""}},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				_ = os.Setenv(k, v)
+				defer func(k string) { require.NoError(t, os.Unsetenv(k)) }(k)
+			}
+
+			tt.config.Name = "consumer"
+			options := func(c *streamconfig.Consumer) {
+				c.Name = "consumer"
+			}
+
+			assert.EqualValues(t, tt.config, streamconfig.TestNewConsumer(t, false, options))
+		})
+	}
 }
 
 func TestProducer(t *testing.T) {
@@ -45,6 +284,7 @@ func TestProducer(t *testing.T) {
 		Standardstream:  standardstreamconfig.Producer{},
 		Logger:          *zap.NewNop(),
 		HandleInterrupt: false,
+		Name:            "",
 	}
 }
 
@@ -55,4 +295,255 @@ func TestProducerDefaults(t *testing.T) {
 
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
+	assert.Equal(t, "producer", config.Name)
+}
+
+func TestProducerUsage(t *testing.T) {
+	p := streamconfig.Producer{Name: "test_config"}
+	usage := p.Usage()
+
+	assert.Contains(t, string(usage), "TEST_CONFIG_KAFKA_MAX_DELIVERY_RETRIES")
+}
+
+func TestProducerEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		envs   map[string]string
+		config streamconfig.Producer
+	}{
+		"Kafka.Brokers": {
+			map[string]string{"PRODUCER_KAFKA_BROKERS": "hello,world"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"hello", "world"}}},
+		},
+
+		"Kafka.Debug (single)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "broker"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{Broker: true}}},
+		},
+
+		"Kafka.Debug (all)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "all"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (true)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "true"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (1)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "1"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (capitalized)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "All"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{All: true}}},
+		},
+
+		"Kafka.Debug (multiple)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "broker,fetch"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{Broker: true, Fetch: true}},
+			},
+		},
+
+		"Kafka.Debug (invalid)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": "nope"},
+			streamconfig.Producer{},
+		},
+
+		"Kafka.Debug (empty)": {
+			map[string]string{"PRODUCER_KAFKA_DEBUG": ""},
+			streamconfig.Producer{},
+		},
+
+		"Kafka.HeartbeatInterval": {
+			map[string]string{"PRODUCER_KAFKA_HEARTBEAT_INTERVAL": "5s"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{HeartbeatInterval: 5 * time.Second}},
+		},
+
+		"Kafka.ID": {
+			map[string]string{"PRODUCER_KAFKA_CLIENT_ID": "hi!"},
+			streamconfig.Producer{Kafka: kafkaconfig.Producer{ID: "hi!"}},
+		},
+
+		"Kafka.MaxDeliveryRetries": {
+			map[string]string{"PRODUCER_KAFKA_MAX_DELIVERY_RETRIES": "1"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxDeliveryRetries: 1},
+			},
+		},
+
+		"Kafka.MaxDeliveryRetries (zero)": {
+			map[string]string{"PRODUCER_KAFKA_MAX_DELIVERY_RETRIES": "0"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxDeliveryRetries: 0},
+			},
+		},
+
+		"Kafka.MaxQueueBufferDuration": {
+			map[string]string{"PRODUCER_KAFKA_MAX_QUEUE_BUFFER_DURATION": "1m"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueBufferDuration: 1 * time.Minute},
+			},
+		},
+
+		"Kafka.MaxQueueSizeKBytes": {
+			map[string]string{"PRODUCER_KAFKA_MAX_QUEUE_SIZE_KBYTES": "100"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueSizeKBytes: 100},
+			},
+		},
+
+		"Kafka.MaxQueueSizeMessages": {
+			map[string]string{"PRODUCER_KAFKA_MAX_QUEUE_SIZE_MESSAGES": "1"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueSizeMessages: 1},
+			},
+		},
+
+		"Kafka.MaxQueueSizeMessages (zero)": {
+			map[string]string{"PRODUCER_KAFKA_MAX_QUEUE_SIZE_MESSAGES": "0"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueSizeMessages: 0},
+			},
+		},
+
+		"Kafka.RequiredAcks (leader)": {
+			map[string]string{"PRODUCER_KAFKA_REQUIRED_ACKS": "1"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckLeader},
+			},
+		},
+
+		"Kafka.RequiredAcks (all)": {
+			map[string]string{"PRODUCER_KAFKA_REQUIRED_ACKS": "-1"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckAll},
+			},
+		},
+
+		"Kafka.RequiredAcks (none)": {
+			map[string]string{"PRODUCER_KAFKA_REQUIRED_ACKS": "0"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckNone},
+			},
+		},
+
+		"Kafka.SecurityProtocol (plaintext)": {
+			map[string]string{"PRODUCER_KAFKA_SECURITY_PROTOCOL": "plaintext"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SecurityProtocol: kafkaconfig.ProtocolPlaintext},
+			},
+		},
+
+		"Kafka.SecurityProtocol (ssl)": {
+			map[string]string{"PRODUCER_KAFKA_SECURITY_PROTOCOL": "SSL"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SecurityProtocol: kafkaconfig.ProtocolSSL},
+			},
+		},
+
+		"Kafka.SecurityProtocol (sasl_plaintext)": {
+			map[string]string{"PRODUCER_KAFKA_SECURITY_PROTOCOL": "sasl_plaintext"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SecurityProtocol: kafkaconfig.ProtocolSASLPlaintext},
+			},
+		},
+
+		"Kafka.SecurityProtocol (sasl_ssl)": {
+			map[string]string{"PRODUCER_KAFKA_SECURITY_PROTOCOL": "sasl_ssl"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SecurityProtocol: kafkaconfig.ProtocolSASLSSL},
+			},
+		},
+
+		"Kafka.SessionTimeout": {
+			map[string]string{"PRODUCER_KAFKA_SESSION_TIMEOUT": "1h"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SessionTimeout: 1 * time.Hour},
+			},
+		},
+
+		"Kafka.SSL.CAPath": {
+			map[string]string{"PRODUCER_KAFKA_SSL_CA_PATH": "/tmp"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{CAPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.CertPath": {
+			map[string]string{"PRODUCER_KAFKA_SSL_CERT_PATH": "/tmp"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{CertPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.CRLPath": {
+			map[string]string{"PRODUCER_KAFKA_SSL_CRL_PATH": "/tmp"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{CRLPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.KeyPassword": {
+			map[string]string{"PRODUCER_KAFKA_SSL_KEY_PASSWORD": "1234"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{KeyPassword: "1234"}},
+			},
+		},
+
+		"Kafka.SSL.KeyPath": {
+			map[string]string{"PRODUCER_KAFKA_SSL_KEY_PATH": "/tmp"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{KeyPath: "/tmp"}},
+			},
+		},
+
+		"Kafka.SSL.KeystorePassword": {
+			map[string]string{"PRODUCER_KAFKA_SSL_KEYSTORE_PASSWORD": "1234"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{KeystorePassword: "1234"}},
+			},
+		},
+
+		"Kafka.SSL.KeystorePath": {
+			map[string]string{"PRODUCER_KAFKA_SSL_KEYSTORE_PATH": "/tmp"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SSL: kafkaconfig.SSL{KeystorePath: "/tmp"}},
+			},
+		},
+
+		"Kafka.Topic": {
+			map[string]string{"PRODUCER_KAFKA_TOPIC": "hello"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Topic: "hello"},
+			},
+		},
+
+		"Kafka.Topics (empty)": {
+			map[string]string{"PRODUCER_KAFKA_TOPIC": ""},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Topic: ""},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				_ = os.Setenv(k, v)
+				defer func(k string) { require.NoError(t, os.Unsetenv(k)) }(k)
+			}
+
+			tt.config.Name = "producer"
+			options := func(c *streamconfig.Producer) {
+				c.Name = "producer"
+			}
+
+			assert.EqualValues(t, tt.config, streamconfig.TestNewProducer(t, false, options))
+		})
+	}
 }

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -27,6 +27,7 @@ func TestConsumer(t *testing.T) {
 		Logger:          *zap.NewNop(),
 		HandleInterrupt: false,
 		Name:            "",
+		AllowEnvironmentBasedConfiguration: false,
 	}
 }
 
@@ -38,6 +39,7 @@ func TestConsumerDefaults(t *testing.T) {
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
 	assert.Equal(t, "consumer", config.Name)
+	assert.True(t, config.AllowEnvironmentBasedConfiguration)
 }
 
 func TestConsumerUsage(t *testing.T) {
@@ -265,8 +267,10 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 			}
 
 			tt.config.Name = "consumer"
+			tt.config.AllowEnvironmentBasedConfiguration = true
 			options := func(c *streamconfig.Consumer) {
 				c.Name = "consumer"
+				c.AllowEnvironmentBasedConfiguration = true
 			}
 
 			assert.EqualValues(t, tt.config, streamconfig.TestNewConsumer(t, false, options))
@@ -285,6 +289,7 @@ func TestProducer(t *testing.T) {
 		Logger:          *zap.NewNop(),
 		HandleInterrupt: false,
 		Name:            "",
+		AllowEnvironmentBasedConfiguration: false,
 	}
 }
 
@@ -296,6 +301,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
 	assert.Equal(t, "producer", config.Name)
+	assert.True(t, config.AllowEnvironmentBasedConfiguration)
 }
 
 func TestProducerUsage(t *testing.T) {
@@ -539,8 +545,10 @@ func TestProducerEnvironmentVariables(t *testing.T) {
 			}
 
 			tt.config.Name = "producer"
+			tt.config.AllowEnvironmentBasedConfiguration = true
 			options := func(c *streamconfig.Producer) {
 				c.Name = "producer"
+				c.AllowEnvironmentBasedConfiguration = true
 			}
 
 			assert.EqualValues(t, tt.config, streamconfig.TestNewProducer(t, false, options))

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -5,6 +5,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/kelseyhightower/envconfig"
 )
 
 // NewConsumer returns a new Consumer configuration struct, containing the
@@ -19,14 +20,22 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 	config.Pubsub = pubsubconfig.ConsumerDefaults
 	config.Standardstream = standardstreamconfig.ConsumerDefaults
 
-	// After we've defined the default values, we overwrite them with any provided
-	// custom configuration values.
+	// After we've defined the default values, we overwrite any currently defined
+	// value with any custom configuration values passed into the `NewConsumer`
+	// function.
 	for _, option := range options {
 		if option == nil {
 			continue
 		}
 
 		option(config)
+	}
+
+	// Finally, we set/overwrite any value with any custom configuration values
+	// provided via environment variables.
+	err := envconfig.Process(config.Name, config)
+	if err != nil {
+		return *config, err
 	}
 
 	// We pass the config by-value, to prevent any race-condition where the
@@ -46,14 +55,22 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 	config.Pubsub = pubsubconfig.ProducerDefaults
 	config.Standardstream = standardstreamconfig.ProducerDefaults
 
-	// After we've defined the default values, we overwrite them with any provided
-	// custom configuration values.
+	// After we've defined the default values, we overwrite any currently defined
+	// value with any custom configuration values passed into the `NewProducer`
+	// function.
 	for _, option := range options {
 		if option == nil {
 			continue
 		}
 
 		option(config)
+	}
+
+	// Finally, we set/overwrite any value with any custom configuration values
+	// provided via environment variables.
+	err := envconfig.Process(config.Name, config)
+	if err != nil {
+		return *config, err
 	}
 
 	// We pass the config by-value, to prevent any race-condition where the

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -32,10 +32,13 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 	}
 
 	// Finally, we set/overwrite any value with any custom configuration values
-	// provided via environment variables.
-	err := envconfig.Process(config.Name, config)
-	if err != nil {
-		return *config, err
+	// provided via environment variables. If `AllowEnvironmentBasedConfiguration`
+	// is set to false, this step is skipped.
+	if config.AllowEnvironmentBasedConfiguration {
+		err := envconfig.Process(config.Name, config)
+		if err != nil {
+			return *config, err
+		}
 	}
 
 	// We pass the config by-value, to prevent any race-condition where the
@@ -67,10 +70,13 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 	}
 
 	// Finally, we set/overwrite any value with any custom configuration values
-	// provided via environment variables.
-	err := envconfig.Process(config.Name, config)
-	if err != nil {
-		return *config, err
+	// provided via environment variables. If `AllowEnvironmentBasedConfiguration`
+	// is set to false, this step is skipped.
+	if config.AllowEnvironmentBasedConfiguration {
+		err := envconfig.Process(config.Name, config)
+		if err != nil {
+			return *config, err
+		}
 	}
 
 	// We pass the config by-value, to prevent any race-condition where the

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -1,6 +1,7 @@
 package streamconfig_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -32,11 +33,48 @@ func TestNewConsumer(t *testing.T) {
 	}
 }
 
-func TestNewConsumer_Options_Nil(t *testing.T) {
+func TestNewConsumer_WithOptions(t *testing.T) {
+	options := func(c *streamconfig.Consumer) {
+		c.Kafka.ID = "test"
+	}
+
+	config, err := streamconfig.NewConsumer(options)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", config.Kafka.ID)
+}
+
+func TestNewConsumer_WithOptions_Nil(t *testing.T) {
 	t.Parallel()
 
 	_, err := streamconfig.NewConsumer(nil)
 	assert.NoError(t, err)
+}
+
+func TestNewConsumer_WithEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	config, err := streamconfig.NewConsumer()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}
+
+func TestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Consumer) {
+		c.Kafka.Brokers = []string{"broker2"}
+		c.Kafka.ID = "test"
+	}
+
+	config, err := streamconfig.NewConsumer(options)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+	assert.Equal(t, "test", config.Kafka.ID)
 }
 
 func TestNewProducer(t *testing.T) {
@@ -62,9 +100,46 @@ func TestNewProducer(t *testing.T) {
 	}
 }
 
-func TestNewProducer_Options_Nil(t *testing.T) {
+func TestNewProducer_WithOptions(t *testing.T) {
+	options := func(c *streamconfig.Producer) {
+		c.Kafka.ID = "test"
+	}
+
+	config, err := streamconfig.NewProducer(options)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", config.Kafka.ID)
+}
+
+func TestNewProducer_WithOptions_Nil(t *testing.T) {
 	t.Parallel()
 
 	_, err := streamconfig.NewProducer(nil)
 	assert.NoError(t, err)
+}
+
+func TestNewProducer_WithEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("PRODUCER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("PRODUCER_KAFKA_BROKERS") // nolint: errcheck
+
+	config, err := streamconfig.NewProducer()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}
+
+func TestNewProducer_WithOptionsAndEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("PRODUCER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("PRODUCER_KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Producer) {
+		c.Kafka.Brokers = []string{"broker2"}
+		c.Kafka.ID = "test"
+	}
+
+	config, err := streamconfig.NewProducer(options)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+	assert.Equal(t, "test", config.Kafka.ID)
 }

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -77,6 +77,21 @@ func TestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "test", config.Kafka.ID)
 }
 
+func TestNewConsumer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Consumer) {
+		c.AllowEnvironmentBasedConfiguration = false
+		c.Kafka.Brokers = []string{"broker2"}
+	}
+
+	config, err := streamconfig.NewConsumer(options)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)
+}
+
 func TestNewProducer(t *testing.T) {
 	t.Parallel()
 
@@ -142,4 +157,19 @@ func TestNewProducer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 
 	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
 	assert.Equal(t, "test", config.Kafka.ID)
+}
+
+func TestNewProducer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Producer) {
+		c.AllowEnvironmentBasedConfiguration = false
+		c.Kafka.Brokers = []string{"broker2"}
+	}
+
+	config, err := streamconfig.NewProducer(options)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)
 }

--- a/streamconfig/inmemconfig/consumer.go
+++ b/streamconfig/inmemconfig/consumer.go
@@ -9,7 +9,7 @@ import (
 type Consumer struct {
 	// Store is the inmem store from which to consume messages. If left undefined,
 	// an internal store will be used.
-	Store *inmemstore.Store
+	Store *inmemstore.Store `ignored:"true"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.

--- a/streamconfig/inmemconfig/producer.go
+++ b/streamconfig/inmemconfig/producer.go
@@ -9,7 +9,7 @@ import (
 type Producer struct {
 	// Store is the inmem store to which to produce messages. If left undefined,
 	// an internal store will be used.
-	Store *inmemstore.Store
+	Store *inmemstore.Store `ignored:"true"`
 }
 
 // ProducerDefaults holds the default values for Producer.

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -22,7 +22,7 @@ type Consumer struct {
 
 	// CommitInterval represents the frequency in milliseconds that the
 	// consumer offsets are auto-committed to Kafka.
-	CommitInterval time.Duration `kafka:"auto.commit.interval.ms,omitempty"`
+	CommitInterval time.Duration `kafka:"auto.commit.interval.ms,omitempty" split_words:"true"`
 
 	// Debug allows tweaking of the default debug values.
 	Debug Debug `kafka:"debug,omitempty"`
@@ -31,7 +31,7 @@ type Consumer struct {
 	// belongs to. This property is required if the consumer uses either the group
 	// management functionality by using subscribe(topic) or the Kafka-based
 	// offset management strategy.
-	GroupID string `kafka:"group.id,omitempty"`
+	GroupID string `kafka:"group.id,omitempty" split_words:"true"`
 
 	// HeartbeatInterval represents The expected time between heartbeats to the
 	// consumer coordinator when using Kafka's group management facilities.
@@ -40,13 +40,13 @@ type Consumer struct {
 	// value must be set lower than `SessionTimeout`, but typically should be set
 	// no higher than 1/3 of that value. It can be adjusted even lower to control
 	// the expected time for normal rebalances.
-	HeartbeatInterval time.Duration `kafka:"heartbeat.interval.ms,omitempty"`
+	HeartbeatInterval time.Duration `kafka:"heartbeat.interval.ms,omitempty" split_words:"true"`
 
 	// ID is an id string to pass to the server when making requests. The purpose
 	// of this is to be able to track the source of requests beyond just IP/port
 	// by allowing a logical application name to be included in server-side
 	// request logging.
-	ID string `kafka:"client.id,omitempty"`
+	ID string `kafka:"client.id,omitempty" envconfig:"client_id"`
 
 	// InitialOffset dictates what to do when there is no initial offset in Kafka
 	// or if the current offset does not exist any more on the server (e.g.
@@ -56,10 +56,10 @@ type Consumer struct {
 	// * OffsetEnd: automatically reset the offset to the latest offset
 	// * none: throw exception to the consumer if no previous offset is found for
 	//   the consumer's group
-	InitialOffset Offset `kafka:"{topic}.auto.offset.reset,omitempty"`
+	InitialOffset Offset `kafka:"{topic}.auto.offset.reset,omitempty" split_words:"true"`
 
 	// SecurityProtocol is the protocol used to communicate with brokers.
-	SecurityProtocol Protocol `kafka:"security.protocol,omitempty"`
+	SecurityProtocol Protocol `kafka:"security.protocol,omitempty" split_words:"true"`
 
 	// SessionTimeout represents the timeout used to detect consumer failures when
 	// using Kafka's group management facility. The consumer sends periodic
@@ -69,7 +69,7 @@ type Consumer struct {
 	// rebalance. Note that the value must be in the allowable range as configured
 	// in the broker configuration by `group.min.session.timeout.ms` and
 	// `group.max.session.timeout.ms`.
-	SessionTimeout time.Duration `kafka:"session.timeout.ms,omitempty"`
+	SessionTimeout time.Duration `kafka:"session.timeout.ms,omitempty" split_words:"true"`
 
 	// SSL contains all configuration values for Kafka SSL connections. Defaults
 	// to an empty struct, meaning no SSL configuration is required to connect to

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -18,7 +18,7 @@ type Producer struct {
 	// discover the full cluster membership (which may change dynamically), this
 	// list need not contain the full set of servers (you may want more than one,
 	// though, in case a server is down).
-	Brokers []string `kafka:"metadata.broker.list,omitempty"`
+	Brokers []string `kafka:"metadata.broker.list,omitempty" split_words:"true"`
 
 	// Debug allows tweaking of the default debug values.
 	Debug Debug `kafka:"debug,omitempty"`
@@ -30,33 +30,34 @@ type Producer struct {
 	// value must be set lower than `SessionTimeout`, but typically should be set
 	// no higher than 1/3 of that value. It can be adjusted even lower to control
 	// the expected time for normal rebalances.
-	HeartbeatInterval time.Duration `kafka:"heartbeat.interval.ms,omitempty"`
+	HeartbeatInterval time.Duration `kafka:"heartbeat.interval.ms,omitempty" split_words:"true"`
 
 	// ID is an id string to pass to the server when making requests. The purpose
 	// of this is to be able to track the source of requests beyond just IP/port
 	// by allowing a logical application name to be included in server-side
 	// request logging.
-	ID string `kafka:"client.id,omitempty"`
+	ID string `kafka:"client.id,omitempty" envconfig:"client_id"`
 
 	// MaxDeliveryRetries dictates how many times to retry sending a failing
 	// MessageSet. Note: retrying may cause reordering. Defaults to 0 retries to
 	// prevent accidental message reordering.
-	MaxDeliveryRetries int `kafka:"message.send.max.retries"`
+	MaxDeliveryRetries int `kafka:"message.send.max.retries" split_words:"true"`
 
 	// MaxQueueBufferDuration is the delay to wait for messages in the producer
 	// queue to accumulate before constructing message batches (MessageSets) to
 	// transmit to brokers. A higher value allows larger and more effective (less
 	// overhead, improved compression) batches of messages to accumulate at the
 	// expense of increased message delivery latency. Defaults to 0.
-	MaxQueueBufferDuration time.Duration `kafka:"queue.buffering.max.ms,omitempty"`
+	MaxQueueBufferDuration time.Duration `kafka:"queue.buffering.max.ms,omitempty" split_words:"true"`
 
 	// MaxQueueSizeKBytes is the maximum total message size sum allowed on the
-	// producer queue. This property has higher priority than MaxQueueSize.
-	MaxQueueSizeKBytes int `kafka:"queue.buffering.max.kbytes,omitempty"`
+	// producer queue. This property has higher priority than
+	// MaxQueueSizeMessages.
+	MaxQueueSizeKBytes int `kafka:"queue.buffering.max.kbytes,omitempty" envconfig:"max_queue_size_kbytes"` // nolint: lll
 
-	// MaxQueueSize dictates the maximum number of messages allowed on the
+	// MaxQueueSizeMessages dictates the maximum number of messages allowed on the
 	// producer queue.
-	MaxQueueSize int `kafka:"queue.buffering.max.messages,omitempty"`
+	MaxQueueSizeMessages int `kafka:"queue.buffering.max.messages,omitempty" split_words:"true"`
 
 	// RequiredAcks indicates how many acknowledgments the leader broker must
 	// receive from ISR brokers before responding to the request:
@@ -67,10 +68,10 @@ type Producer struct {
 	// replicas (ISRs).
 	//
 	// Defaults to `AckLeader`.
-	RequiredAcks Ack `kafka:"{topic}.request.required.acks"`
+	RequiredAcks Ack `kafka:"{topic}.request.required.acks" split_words:"true"`
 
 	// SecurityProtocol is the protocol used to communicate with brokers.
-	SecurityProtocol Protocol `kafka:"security.protocol,omitempty"`
+	SecurityProtocol Protocol `kafka:"security.protocol,omitempty" split_words:"true"`
 
 	// SessionTimeout represents the timeout used to detect consumer failures when
 	// using Kafka's group management facility. The consumer sends periodic
@@ -80,7 +81,7 @@ type Producer struct {
 	// rebalance. Note that the value must be in the allowable range as configured
 	// in the broker configuration by `group.min.session.timeout.ms` and
 	// `group.max.session.timeout.ms`.
-	SessionTimeout time.Duration `kafka:"session.timeout.ms,omitempty"`
+	SessionTimeout time.Duration `kafka:"session.timeout.ms,omitempty" split_words:"true"`
 
 	// SSL contains all configuration values for Kafka SSL connections. Defaults
 	// to an empty struct, meaning no SSL configuration is required to connect to
@@ -121,7 +122,7 @@ var ProducerDefaults = Producer{
 	MaxDeliveryRetries:     0,
 	MaxQueueBufferDuration: time.Duration(0),
 	MaxQueueSizeKBytes:     2097151,
-	MaxQueueSize:           10000000,
+	MaxQueueSizeMessages:   10000000,
 	RequiredAcks:           AckLeader,
 	SessionTimeout:         30 * time.Second,
 	SSL:                    SSL{},

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -32,7 +32,7 @@ func TestProducer(t *testing.T) {
 		MaxDeliveryRetries:     0,
 		MaxQueueBufferDuration: time.Duration(0),
 		MaxQueueSizeKBytes:     0,
-		MaxQueueSize:           0,
+		MaxQueueSizeMessages:   0,
 		RequiredAcks:           kafkaconfig.AckAll,
 		SecurityProtocol:       kafkaconfig.ProtocolPlaintext,
 		SessionTimeout:         time.Duration(0),
@@ -51,7 +51,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, 0, config.MaxDeliveryRetries)
 	assert.Equal(t, 0*time.Second, config.MaxQueueBufferDuration)
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)
-	assert.Equal(t, 10000000, config.MaxQueueSize)
+	assert.Equal(t, 10000000, config.MaxQueueSizeMessages)
 	assert.EqualValues(t, kafkaconfig.AckLeader, config.RequiredAcks)
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
@@ -150,12 +150,12 @@ func TestProducer_ConfigMap(t *testing.T) {
 		},
 
 		"maxQueueSize": {
-			&kafkaconfig.Producer{MaxQueueSize: 99},
+			&kafkaconfig.Producer{MaxQueueSizeMessages: 99},
 			&kafka.ConfigMap{"queue.buffering.max.messages": 99},
 		},
 
 		"maxQueueSize (empty)": {
-			&kafkaconfig.Producer{MaxQueueSize: 0},
+			&kafkaconfig.Producer{MaxQueueSizeMessages: 0},
 			&kafka.ConfigMap{},
 		},
 

--- a/streamconfig/standardstreamconfig/consumer.go
+++ b/streamconfig/standardstreamconfig/consumer.go
@@ -11,7 +11,7 @@ type Consumer struct {
 	// Reader is the object that implements the io.ReadCloser interface
 	// (io.Reader + io.Closer). This object is used to read messages from the
 	// stream. Defaults to `os.Stdin`.
-	Reader io.ReadCloser
+	Reader io.ReadCloser `ignored:"true"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.

--- a/streamconfig/standardstreamconfig/producer.go
+++ b/streamconfig/standardstreamconfig/producer.go
@@ -10,7 +10,7 @@ import (
 type Producer struct {
 	// Writer is the object that implements the io.Writer interface. This object
 	// is used to write new messages to the stream. Defaults to `os.Stdout`.
-	Writer io.Writer
+	Writer io.Writer `ignored:"true"`
 }
 
 // ProducerDefaults holds the default values for Producer.

--- a/streamconfig/testing.go
+++ b/streamconfig/testing.go
@@ -26,6 +26,7 @@ func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) C
 		c.Logger = zap.Logger{}
 		c.HandleInterrupt = false
 		c.Name = ""
+		c.AllowEnvironmentBasedConfiguration = false
 	}
 
 	for _, option := range options {
@@ -56,6 +57,7 @@ func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) P
 		p.Logger = zap.Logger{}
 		p.HandleInterrupt = false
 		p.Name = ""
+		p.AllowEnvironmentBasedConfiguration = false
 	}
 
 	for _, option := range options {

--- a/streamconfig/testing.go
+++ b/streamconfig/testing.go
@@ -1,0 +1,73 @@
+package streamconfig
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestNewConsumer returns a new consumer configuration struct, optionally with
+// the default values removed.
+func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) Consumer {
+	c, err := NewConsumer()
+	require.NoError(tb, err)
+
+	if !defaults {
+		c.Inmem = inmemconfig.Consumer{Store: nil}
+		c.Kafka = kafkaconfig.Consumer{}
+		c.Pubsub = pubsubconfig.Consumer{}
+		c.Standardstream = standardstreamconfig.Consumer{}
+		c.Logger = zap.Logger{}
+		c.HandleInterrupt = false
+		c.Name = ""
+	}
+
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
+		option(&c)
+	}
+
+	err = envconfig.Process(c.Name, &c)
+	require.NoError(tb, err)
+
+	return c
+}
+
+// TestNewProducer returns a new producer configuration struct, optionally with
+// the default values removed.
+func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) Producer {
+	p, err := NewProducer()
+	require.NoError(tb, err)
+
+	if !defaults {
+		p.Inmem = inmemconfig.Producer{Store: nil}
+		p.Kafka = kafkaconfig.Producer{}
+		p.Pubsub = pubsubconfig.Producer{}
+		p.Standardstream = standardstreamconfig.Producer{}
+		p.Logger = zap.Logger{}
+		p.HandleInterrupt = false
+		p.Name = ""
+	}
+
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
+		option(&p)
+	}
+
+	err = envconfig.Process(p.Name, &p)
+	require.NoError(tb, err)
+
+	return p
+}

--- a/streamconfig/testing_test.go
+++ b/streamconfig/testing_test.go
@@ -1,0 +1,118 @@
+package streamconfig_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestTestNewConsumer(t *testing.T) {
+	c1, _ := streamconfig.NewConsumer()
+	c2 := streamconfig.TestNewConsumer(t, true)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewConsumer_WithoutDefaults(t *testing.T) {
+	c1 := streamconfig.Consumer{}
+	c2 := streamconfig.TestNewConsumer(t, false)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewConsumer_WithOptions(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	options := func(c *streamconfig.Consumer) {
+		c.Logger = *logger
+	}
+
+	c1 := streamconfig.Consumer{Logger: *logger}
+	c2 := streamconfig.TestNewConsumer(t, false, options)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewConsumer_WithEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
+
+	c1 := streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Brokers: []string{"broker1"}}}
+	c2 := streamconfig.TestNewConsumer(t, false)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Consumer) {
+		c.Kafka.Brokers = []string{"broker2"}
+		c.Kafka.ID = "test"
+	}
+
+	c1 := streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Brokers: []string{"broker1"}, ID: "test"}}
+	c2 := streamconfig.TestNewConsumer(t, false, options)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewProducer(t *testing.T) {
+	p1, _ := streamconfig.NewProducer()
+	p2 := streamconfig.TestNewProducer(t, true)
+
+	assert.EqualValues(t, p1, p2)
+}
+
+func TestTestNewProducer_WithoutDefaults(t *testing.T) {
+	p1 := streamconfig.Producer{}
+	p2 := streamconfig.TestNewProducer(t, false)
+
+	assert.EqualValues(t, p1, p2)
+}
+
+func TestTestNewProducer_WithOptions(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	options := func(c *streamconfig.Producer) {
+		c.Logger = *logger
+	}
+
+	p1 := streamconfig.Producer{Logger: *logger}
+	p2 := streamconfig.TestNewProducer(t, false, options)
+
+	assert.EqualValues(t, p1, p2)
+}
+
+func TestTestNewProducer_WithEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
+
+	c1 := streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"broker1"}}}
+	c2 := streamconfig.TestNewProducer(t, false)
+
+	assert.EqualValues(t, c1, c2)
+}
+
+func TestTestNewProducer_WithOptionsAndEnvironmentVariables(t *testing.T) {
+	_ = os.Setenv("KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
+
+	options := func(c *streamconfig.Producer) {
+		c.Kafka.Brokers = []string{"broker2"}
+		c.Kafka.ID = "test"
+	}
+
+	c1 := streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"broker1"}, ID: "test"}}
+	c2 := streamconfig.TestNewProducer(t, false, options)
+
+	assert.EqualValues(t, c1, c2)
+}


### PR DESCRIPTION
So, I was all jacked-up, ready to hit the ground running and take this bad boy for a spin...

... and then I realised there's no way to actually configure your stream client of choice _outside_ of the code-base 😱 

I thought about rolling my own, but then remembered I saw Kelsey Hightower give a presentation once where he showed one of his Go packages, which did exactly what I needed. So I chose that one instead, and it works great:

https://github.com/kelseyhightower/envconfig

Couple of additions in this PR:

- [x] You can now control (almost) all configuration values using environment variables
- [x] There's now a clear hierarchy when it comes to configuration values: `environment variables` > `in-code options` > `default`
- [x] You can optionally use `Usage()` on the configuration struct to get a tab-based printout of the configurations.
- [x] You can completely disallow environment-based configuration by setting `AllowEnvironmentBasedConfiguration` to `false` (defaults to `true`).

Here's an example of the current configuration values:

```
This application is configured via the environment. The following environment
variables can be used:

KEY                                     TYPE                              DEFAULT    REQUIRED    DESCRIPTION
CONSUMER_KAFKA_BROKERS                  Comma-separated list of String                           
CONSUMER_KAFKA_COMMIT_INTERVAL          Duration                                                 
CONSUMER_KAFKA_DEBUG                    Debug                                                    
CONSUMER_KAFKA_GROUP_ID                 String                                                   
CONSUMER_KAFKA_HEARTBEAT_INTERVAL       Duration                                                 
CONSUMER_KAFKA_CLIENT_ID                String                                                   
CONSUMER_KAFKA_INITIAL_OFFSET           Offset                                                   
CONSUMER_KAFKA_SECURITY_PROTOCOL        Protocol                                                 
CONSUMER_KAFKA_SESSION_TIMEOUT          Duration                                                 
CONSUMER_KAFKA_SSL_CA_PATH              String                                                   
CONSUMER_KAFKA_SSL_CERT_PATH            String                                                   
CONSUMER_KAFKA_SSL_CRL_PATH             String                                                   
CONSUMER_KAFKA_SSL_KEY_PASSWORD         String                                                   
CONSUMER_KAFKA_SSL_KEY_PATH             String                                                   
CONSUMER_KAFKA_SSL_KEYSTORE_PASSWORD    String                                                   
CONSUMER_KAFKA_SSL_KEYSTORE_PATH        String                                                   
CONSUMER_KAFKA_TOPICS                   Comma-separated list of String                           
```

```
This application is configured via the environment. The following environment
variables can be used:

KEY                                         TYPE                              DEFAULT    REQUIRED    DESCRIPTION
PRODUCER_KAFKA_BROKERS                      Comma-separated list of String                           
PRODUCER_KAFKA_DEBUG                        Debug                                                    
PRODUCER_KAFKA_HEARTBEAT_INTERVAL           Duration                                                 
PRODUCER_KAFKA_CLIENT_ID                    String                                                   
PRODUCER_KAFKA_MAX_DELIVERY_RETRIES         Integer                                                  
PRODUCER_KAFKA_MAX_QUEUE_BUFFER_DURATION    Duration                                                 
PRODUCER_KAFKA_MAX_QUEUE_SIZE_KBYTES        Integer                                                  
PRODUCER_KAFKA_MAX_QUEUE_SIZE_MESSAGES      Integer                                                  
PRODUCER_KAFKA_REQUIRED_ACKS                Ack                                                      
PRODUCER_KAFKA_SECURITY_PROTOCOL            Protocol                                                 
PRODUCER_KAFKA_SESSION_TIMEOUT              Duration                                                 
PRODUCER_KAFKA_SSL_CA_PATH                  String                                                   
PRODUCER_KAFKA_SSL_CERT_PATH                String                                                   
PRODUCER_KAFKA_SSL_CRL_PATH                 String                                                   
PRODUCER_KAFKA_SSL_KEY_PASSWORD             String                                                   
PRODUCER_KAFKA_SSL_KEY_PATH                 String                                                   
PRODUCER_KAFKA_SSL_KEYSTORE_PASSWORD        String                                                   
PRODUCER_KAFKA_SSL_KEYSTORE_PATH            String                                                   
PRODUCER_KAFKA_TOPIC                        String                                                   
```

You can then do things like:

```bash
CONSUMER_KAFKA_COMMIT_INTERVAL="300ms"
PRODUCER_KAFKA_SSL_CRL_PATH="/tmp"
PRODUCER_KAFKA_BROKERS="broker1,broker2"
PRODUCER_KAFKA_MAX_DELIVERY_RETRIES="10"
PRODUCER_KAFKA_REQUIRED_ACKS="-1"
PRODUCER_KAFKA_SECURITY_PROTOCOL="ssl"
PRODUCER_KAFKA_DEBUG="all"
PRODUCER_KAFKA_DEBUG="fetch,consumer"
```

There's still a lot of overlap between producer and consumer configurations, so I'm still considering pulling them into a single `Config` struct, and have the differences live under two nested `Consumer` and `Producer` structs, but for now this works.