### PR TITLE
Add support for configurable message compression

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,6 +13,11 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/kelseyhightower/envconfig"
+  packages = ["."]
+  revision = "1f94cfab3dcc47159a6dcb83588baa3d8260e78a"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -55,6 +60,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e1bda4c9a156dca3d22f8ce91ebf87f4644d603b3e511e062150094c800b82e5"
+  inputs-digest = "5cd50c5e23880e73065368d40931e6cf0e8d55fe5ee66d2890c62105247115bd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,3 +5,7 @@
 [[constraint]]
   name = "github.com/confluentinc/confluent-kafka-go"
   revision = "767701354ee866ea3a63110035df26a8cccc3dee"
+
+[[constraint]]
+  name = "github.com/kelseyhightower/envconfig"
+  revision = "1f94cfab3dcc47159a6dcb83588baa3d8260e78a"

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -167,6 +167,11 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 		return nil, err
 	}
 
+	config.Logger.Info(
+		"Finished parsing Kafka client configurations.",
+		zap.Any("config", kconfig),
+	)
+
 	// Instantiate a new rdkafka-based Kafka producer.
 	kafkaproducer, err := kafka.NewProducer(kconfig)
 	if err != nil {

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -318,6 +318,13 @@ func TestProducerEnvironmentVariables(t *testing.T) {
 		envs   map[string]string
 		config streamconfig.Producer
 	}{
+		"Kafka.BatchMessageSize": {
+			map[string]string{"PRODUCER_KAFKA_BATCH_MESSAGE_SIZE": "10000"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{BatchMessageSize: 10000},
+			},
+		},
+
 		"Kafka.CompressionCodec (none)": {
 			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "none"},
 			streamconfig.Producer{

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -318,6 +318,34 @@ func TestProducerEnvironmentVariables(t *testing.T) {
 		envs   map[string]string
 		config streamconfig.Producer
 	}{
+		"Kafka.CompressionCodec (none)": {
+			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "none"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionNone},
+			},
+		},
+
+		"Kafka.CompressionCodec (gzip)": {
+			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "gzip"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionGZIP},
+			},
+		},
+
+		"Kafka.CompressionCodec (snappy)": {
+			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "snappy"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionSnappy},
+			},
+		},
+
+		"Kafka.CompressionCodec (lz4)": {
+			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "lz4"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionLZ4},
+			},
+		},
+
 		"Kafka.Brokers": {
 			map[string]string{"PRODUCER_KAFKA_BROKERS": "hello,world"},
 			streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"hello", "world"}}},

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -346,6 +346,13 @@ func TestProducerEnvironmentVariables(t *testing.T) {
 			},
 		},
 
+		"Kafka.CompressionCodec (capitalized)": {
+			map[string]string{"PRODUCER_KAFKA_COMPRESSION_CODEC": "LZ4"},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionLZ4},
+			},
+		},
+
 		"Kafka.Brokers": {
 			map[string]string{"PRODUCER_KAFKA_BROKERS": "hello,world"},
 			streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"hello", "world"}}},

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/zap"
 )
 
 // NewConsumer returns a new Consumer configuration struct, containing the
@@ -40,6 +41,11 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 			return *config, err
 		}
 	}
+
+	config.Logger.Info(
+		"Finished preparing consumer configuration.",
+		zap.Any("config", config),
+	)
 
 	// We pass the config by-value, to prevent any race-condition where the
 	// original config struct is modified after the fact.
@@ -78,6 +84,11 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 			return *config, err
 		}
 	}
+
+	config.Logger.Info(
+		"Finished preparing producer configuration.",
+		zap.Any("config", config),
+	)
 
 	// We pass the config by-value, to prevent any race-condition where the
 	// original config struct is modified after the fact.

--- a/streamconfig/kafkaconfig/options.go
+++ b/streamconfig/kafkaconfig/options.go
@@ -213,3 +213,10 @@ const (
 func (c Compression) ConfigValue() kafka.ConfigValue {
 	return string(c)
 }
+
+// Set is used by the `envconfig` package to set the right value based off of
+// the provided environment variables.
+func (c *Compression) Set(value string) error {
+	*c = Compression(strings.ToLower(value))
+	return nil
+}

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -10,6 +10,10 @@ import (
 // Producer is a value-object, containing all user-configurable configuration
 // values that dictate how the Kafka client's producer will behave.
 type Producer struct {
+	// BatchMessageSize sets the maximum number of messages batched in one
+	// MessageSet. The total MessageSet size is also limited by message.max.bytes.
+	BatchMessageSize int `kafka:"batch.num.messages,omitempty" split_words:"true"`
+
 	// Brokers is a list of host/port pairs to use for establishing the initial
 	// connection to the Kafka cluster. The client will make use of all servers
 	// irrespective of which servers are specified here for bootstrapping — this
@@ -109,14 +113,11 @@ type staticProducer struct {
 	// accumulator. A lower number yields larger and more effective batches.
 	// Set to 100, and non-configurable for now.
 	QueueBackpressureThreshold int `kafka:"queue.buffering.backpressure.threshold"`
-
-	// BatchMessageSize sets the maximum number of messages batched in one
-	// MessageSet. The total MessageSet size is also limited by message.max.bytes.
-	BatchMessageSize int `kafka:"batch.num.messages"`
 }
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
+	BatchMessageSize:       100000,
 	CompressionCodec:       CompressionSnappy,
 	Debug:                  Debug{},
 	HeartbeatInterval:      10 * time.Second,
@@ -131,7 +132,6 @@ var ProducerDefaults = Producer{
 
 var staticProducerDefaults = &staticProducer{
 	QueueBackpressureThreshold: 100,
-	BatchMessageSize:           100000,
 }
 
 // ConfigMap converts the current configuration into a format known to the

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -20,6 +20,12 @@ type Producer struct {
 	// though, in case a server is down).
 	Brokers []string `kafka:"metadata.broker.list,omitempty" split_words:"true"`
 
+	// CompressionCodec sets the compression codec to use for compressing message
+	// sets. This is the default value for all topics, may be overridden by the
+	// topic configuration property compression.codec. Set tot `Snappy` by
+	// default.
+	CompressionCodec Compression `kafka:"compression.codec,omitempty" split_words:"true"`
+
 	// Debug allows tweaking of the default debug values.
 	Debug Debug `kafka:"debug,omitempty"`
 
@@ -104,12 +110,6 @@ type staticProducer struct {
 	// Set to 100, and non-configurable for now.
 	QueueBackpressureThreshold int `kafka:"queue.buffering.backpressure.threshold"`
 
-	// CompressionCodec sets the compression codec to use for compressing message
-	// sets. This is the default value for all topics, may be overridden by the
-	// topic configuration property compression.codec. Set tot `Snappy`,
-	// non-configurable.
-	CompressionCodec Compression `kafka:"compression.codec"`
-
 	// BatchMessageSize sets the maximum number of messages batched in one
 	// MessageSet. The total MessageSet size is also limited by message.max.bytes.
 	BatchMessageSize int `kafka:"batch.num.messages"`
@@ -117,6 +117,7 @@ type staticProducer struct {
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
+	CompressionCodec:       CompressionSnappy,
 	Debug:                  Debug{},
 	HeartbeatInterval:      10 * time.Second,
 	MaxDeliveryRetries:     0,
@@ -130,7 +131,6 @@ var ProducerDefaults = Producer{
 
 var staticProducerDefaults = &staticProducer{
 	QueueBackpressureThreshold: 100,
-	CompressionCodec:           CompressionSnappy,
 	BatchMessageSize:           100000,
 }
 

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -12,7 +12,6 @@ import (
 
 var producerDefaults = map[string]interface{}{
 	"queue.buffering.backpressure.threshold": 100,
-	"compression.codec":                      "snappy",
 	"batch.num.messages":                     100000,
 }
 
@@ -26,6 +25,7 @@ func TestProducer(t *testing.T) {
 
 	_ = kafkaconfig.Producer{
 		Brokers:                []string{},
+		CompressionCodec:       kafkaconfig.CompressionNone,
 		Debug:                  kafkaconfig.Debug{All: true},
 		HeartbeatInterval:      time.Duration(0),
 		ID:                     "",
@@ -47,6 +47,7 @@ func TestProducerDefaults(t *testing.T) {
 	config := kafkaconfig.ProducerDefaults
 
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
+	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
 	assert.Equal(t, 10*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, 0, config.MaxDeliveryRetries)
 	assert.Equal(t, 0*time.Second, config.MaxQueueBufferDuration)
@@ -77,6 +78,26 @@ func TestProducer_ConfigMap(t *testing.T) {
 		"brokers (empty)": {
 			&kafkaconfig.Producer{Brokers: []string{}},
 			&kafka.ConfigMap{},
+		},
+
+		"compressionCodec (none)": {
+			&kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionNone},
+			&kafka.ConfigMap{"compression.codec": "none"},
+		},
+
+		"compressionCodec (gzip)": {
+			&kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionGZIP},
+			&kafka.ConfigMap{"compression.codec": "gzip"},
+		},
+
+		"compressionCodec (Snappy)": {
+			&kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionSnappy},
+			&kafka.ConfigMap{"compression.codec": "snappy"},
+		},
+
+		"compressionCodec (lz4)": {
+			&kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionLZ4},
+			&kafka.ConfigMap{"compression.codec": "lz4"},
 		},
 
 		"debug (all)": {

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -12,7 +12,6 @@ import (
 
 var producerDefaults = map[string]interface{}{
 	"queue.buffering.backpressure.threshold": 100,
-	"batch.num.messages":                     100000,
 }
 
 var producerOmitempties = []string{
@@ -24,6 +23,7 @@ func TestProducer(t *testing.T) {
 	t.Parallel()
 
 	_ = kafkaconfig.Producer{
+		BatchMessageSize:       0,
 		Brokers:                []string{},
 		CompressionCodec:       kafkaconfig.CompressionNone,
 		Debug:                  kafkaconfig.Debug{All: true},
@@ -46,6 +46,7 @@ func TestProducerDefaults(t *testing.T) {
 
 	config := kafkaconfig.ProducerDefaults
 
+	assert.Equal(t, 100000, config.BatchMessageSize)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
 	assert.Equal(t, 10*time.Second, config.HeartbeatInterval)
@@ -68,6 +69,11 @@ func TestProducer_ConfigMap(t *testing.T) {
 		"empty": {
 			&kafkaconfig.Producer{},
 			&kafka.ConfigMap{},
+		},
+
+		"batchMessageSize": {
+			&kafkaconfig.Producer{BatchMessageSize: 10},
+			&kafka.ConfigMap{"batch.num.messages": 10},
 		},
 
 		"brokers": {


### PR DESCRIPTION
@jurriaan sent me a link to http://blog.yaorenjie.com/2017/01/03/Kafka-0-10-Compression-Benchmark/, so I wanted to do some testing with LZ4 compression.

This PR makes the compression codec configurable.