### PR TITLE
Moar tweaks and fixes

### DIFF
--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamclient"
-	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 			"kafka",
 			"*kafkaclient.Consumer",
 			func(c *streamconfig.Consumer) {
-				c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 				c.Kafka.Topics = []string{"test"}
 				c.Kafka.GroupID = "test"
 			},

--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -84,6 +84,11 @@ func (c *Consumer) Close() error {
 		// Wait until the WaitGroup counter is zero. This makes sure we block the
 		// close call until the reader has been closed, to prevent reading errors.
 		c.wg.Wait()
+
+		// Let's flush all logs still in the buffer, since this consumer is no
+		// longer useful after this point. We ignore any errors returned by sync, as
+		// it is known to return unexpected errors. See: https://git.io/vpJFk
+		_ = c.logger.Sync() // nolint: gas
 	})
 
 	return nil

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -70,6 +70,11 @@ func (p *Producer) Close() error {
 		// Wait until the WaitGroup counter is zero. This makes sure we block the
 		// close call until all messages have been delivered, to prevent data-loss.
 		p.wg.Wait()
+
+		// Let's flush all logs still in the buffer, since this producer is no
+		// longer useful after this point. We ignore any errors returned by sync, as
+		// it is known to return unexpected errors. See: https://git.io/vpJFk
+		_ = p.logger.Sync() // nolint: gas
 	})
 
 	return nil

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -122,8 +122,9 @@ func (c *Consumer) Close() (err error) {
 		c.quit = nil
 
 		// Let's flush all logs still in the buffer, since this consumer is no
-		// longer useful after this point.
-		err = c.logger.Sync()
+		// longer useful after this point. We ignore any errors returned by sync, as
+		// it is known to return unexpected errors. See: https://git.io/vpJFk
+		_ = c.logger.Sync() // nolint: gas
 	})
 
 	return err

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
@@ -135,7 +137,7 @@ func TestIntegrationConsumer_Ack(t *testing.T) {
 
 	consumer, closer := kafkaclient.TestConsumer(t, topicOrGroup)
 
-	message := kafkaclient.TestMessageFromConsumer(t, consumer)
+	message := streamclient.TestMessageFromConsumer(t, consumer)
 
 	// Without ack'ing the message, the offset for the consumer group is still set
 	// to -1001 (which is a special int, signaling "no offset available yet").
@@ -178,7 +180,7 @@ func TestIntegrationConsumer_Ack(t *testing.T) {
 	assert.Equal(t, int64(1), int64(offsets[0].Offset))
 
 	consumer, closer = kafkaclient.TestConsumer(t, topicOrGroup)
-	message = kafkaclient.TestMessageFromConsumer(t, consumer)
+	message = streamclient.TestMessageFromConsumer(t, consumer)
 
 	// Ack'ing the second message results in another increase in offset.
 	err = consumer.Ack(message)
@@ -198,7 +200,7 @@ func TestIntegrationMessage_Ack_WithClosedConsumer(t *testing.T) {
 	kafkaclient.TestProduceMessages(t, topicOrGroup, "hello world")
 
 	consumer, closer := kafkaclient.TestConsumer(t, topicOrGroup)
-	message := kafkaclient.TestMessageFromConsumer(t, consumer)
+	message := streamclient.TestMessageFromConsumer(t, consumer)
 	closer()
 
 	err := consumer.Ack(message)
@@ -212,7 +214,7 @@ func BenchmarkIntegrationConsumer_Messages(b *testing.B) {
 	line := `{"number":%d}` + "\n"
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":         kafkaclient.TestBrokerAddress,
+		"metadata.broker.list":         kafkaconfig.TestBrokerAddress,
 		"go.batch.producer":            true,
 		"go.delivery.reports":          false,
 		"queue.buffering.max.messages": b.N,
@@ -251,7 +253,7 @@ func BenchmarkIntegrationConsumer_Messages(b *testing.B) {
 	// We use the default (production-like) config in this benchmark, to simulate
 	// real-world usage as best as possible.
 	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 		c.Kafka.GroupID = topicAndGroup
 		c.Kafka.Topics = []string{topicAndGroup}
 	}

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -109,8 +109,9 @@ func (p *Producer) Close() (err error) {
 		p.kafka.Close()
 
 		// Let's flush all logs still in the buffer, since this producer is no
-		// longer useful after this point.
-		err = p.logger.Sync()
+		// longer useful after this point. We ignore any errors returned by sync, as
+		// it is known to return unexpected errors. See: https://git.io/vpJFk
+		_ = p.logger.Sync() // nolint: gas
 	})
 
 	return err

--- a/streamclient/kafkaclient/producer_test.go
+++ b/streamclient/kafkaclient/producer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/stretchr/testify/assert"
@@ -115,7 +116,7 @@ func BenchmarkIntegrationProducer_Messages(b *testing.B) {
 	// We use the default (production-like) config in this benchmark, to simulate
 	// real-world usage as best as possible.
 	options := func(c *streamconfig.Producer) {
-		c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 		c.Kafka.Topic = topic
 	}
 

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -41,24 +41,6 @@ func TestProducer(tb testing.TB, topic string, options ...func(c *streamconfig.P
 	return producer, func() { require.NoError(tb, producer.Close()) }
 }
 
-// TestMessageFromConsumer returns a single message, consumed from the provided
-// consumer. It has a built-in timeout mechanism to prevent the test from
-// getting stuck.
-func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) streammsg.Message {
-	tb.Helper()
-
-	select {
-	case m := <-consumer.Messages():
-		require.NotNil(tb, m)
-
-		return m
-	case <-time.After(time.Duration(5*TestTimeoutMultiplier) * time.Second):
-		require.Fail(tb, "Timeout while waiting for message to be returned.")
-	}
-
-	return streammsg.Message{}
-}
-
 // TestMessageFromTopic returns a single message, consumed from the provided
 // topic. It has a built-in timeout mechanism to prevent the test from getting
 // stuck.

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -140,8 +140,8 @@ func TestOffsets(tb testing.TB, message streammsg.Message) []kafka.TopicPartitio
 	consumer, closer := testKafkaConsumer(tb, message.Topic, false)
 	defer closer()
 
-	o := streammsg.MessageOpqaue(&message).(opaque)
-	offsets, err := consumer.Committed([]kafka.TopicPartition{*o.toppar}, 1000*testutils.TimeoutMultiplier)
+	tp := []kafka.TopicPartition{*streammsg.MessageOpqaue(&message).(opaque).toppar}
+	offsets, err := consumer.Committed(tp, 2000*testutils.TimeoutMultiplier)
 	require.NoError(tb, err)
 
 	return offsets

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -152,6 +152,12 @@ func TestOffsets(tb testing.TB, message streammsg.Message) []kafka.TopicPartitio
 func TestConsumerConfig(tb testing.TB, topicAndGroup string, options ...func(c *streamconfig.Consumer)) []func(c *streamconfig.Consumer) {
 	var allOptions []func(c *streamconfig.Consumer)
 
+	opts := func(c *streamconfig.Consumer) {
+		c.Kafka = kafkaconfig.TestConsumer(tb)
+		c.Kafka.GroupID = topicAndGroup
+		c.Kafka.Topics = []string{topicAndGroup}
+	}
+
 	if testing.Verbose() {
 		logger, err := zap.NewDevelopment()
 		require.NoError(tb, err)
@@ -162,17 +168,6 @@ func TestConsumerConfig(tb testing.TB, topicAndGroup string, options ...func(c *
 		}
 
 		allOptions = append(allOptions, verbose)
-	}
-
-	opts := func(c *streamconfig.Consumer) {
-		c.Kafka.ID = "testConsumer"
-		c.Kafka.SessionTimeout = time.Duration(1000*TestTimeoutMultiplier) * time.Millisecond
-		c.Kafka.HeartbeatInterval = time.Duration(150*TestTimeoutMultiplier) * time.Millisecond
-		c.Kafka.CommitInterval = time.Duration(500*TestTimeoutMultiplier) * time.Millisecond
-		c.Kafka.Brokers = []string{TestBrokerAddress}
-		c.Kafka.GroupID = topicAndGroup
-		c.Kafka.Topics = []string{topicAndGroup}
-		c.Kafka.InitialOffset = kafkaconfig.OffsetBeginning
 	}
 
 	return append(append(allOptions, opts), options...)

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
@@ -138,7 +139,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, consumer.Close()) }()
 
-	message := kafkaclient.TestMessageFromConsumer(t, consumer)
+	message := streamclient.TestMessageFromConsumer(t, consumer)
 
 	assert.Equal(t, "hello world", string(message.Value))
 }

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
@@ -113,7 +114,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	topicAndGroup := testutils.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaclient.TestBrokerAddress,
+		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
 		"produce.offset.report": false,
 	}
 	producer, err := kafka.NewProducer(config)
@@ -128,7 +129,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	producer.Close()
 
 	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 		c.Kafka.Topics = []string{topicAndGroup}
 		c.Kafka.GroupID = topicAndGroup
 	}
@@ -149,7 +150,7 @@ func TestIntegrationTestMessagesFromTopic(t *testing.T) {
 	topicAndGroup := testutils.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaclient.TestBrokerAddress,
+		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
 		"produce.offset.report": false,
 	}
 	producer, err := kafka.NewProducer(config)
@@ -215,7 +216,7 @@ func TestIntegrationTestProduceMessages(t *testing.T) {
 			println(topicAndGroup)
 
 			config := &kafka.ConfigMap{
-				"metadata.broker.list":     kafkaclient.TestBrokerAddress,
+				"metadata.broker.list":     kafkaconfig.TestBrokerAddress,
 				"group.id":                 topicAndGroup,
 				"enable.partition.eof":     true,
 				"go.events.channel.enable": true,
@@ -257,7 +258,7 @@ func TestIntegrationTestOffsets(t *testing.T) {
 	topicAndGroup := testutils.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaclient.TestBrokerAddress,
+		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
 		"produce.offset.report": false,
 	}
 	producer, err := kafka.NewProducer(config)
@@ -270,7 +271,7 @@ func TestIntegrationTestOffsets(t *testing.T) {
 	producer.Close()
 
 	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 		c.Kafka.Topics = []string{topicAndGroup}
 		c.Kafka.GroupID = topicAndGroup
 	}

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamclient"
-	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,7 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 			"kafka",
 			"*kafkaclient.Producer",
 			func(c *streamconfig.Producer) {
-				c.Kafka.Brokers = []string{kafkaclient.TestBrokerAddress}
+				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 				c.Kafka.Topic = "test"
 			},
 		},

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -89,6 +89,11 @@ func (c *Consumer) Close() error {
 	// close call until the reader has been closed, to prevent reading errors.
 	c.wg.Wait()
 
+	// Let's flush all logs still in the buffer, since this consumer is no
+	// longer useful after this point. We ignore any errors returned by sync, as
+	// it is known to return unexpected errors. See: https://git.io/vpJFk
+	_ = c.logger.Sync() // nolint: gas
+
 	return nil
 }
 

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -72,6 +72,11 @@ func (p *Producer) Close() error {
 	// close call until all messages have been delivered, to prevent data-loss.
 	p.wg.Wait()
 
+	// Let's flush all logs still in the buffer, since this producer is no
+	// longer useful after this point. We ignore any errors returned by sync, as
+	// it is known to return unexpected errors. See: https://git.io/vpJFk
+	_ = p.logger.Sync() // nolint: gas
+
 	return nil
 }
 

--- a/streamclient/testing.go
+++ b/streamclient/testing.go
@@ -1,0 +1,29 @@
+package streamclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/streamutils/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessageFromConsumer returns a single message, consumed from the provided
+// consumer. It has a built-in timeout mechanism to prevent the test from
+// getting stuck.
+func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) streammsg.Message {
+	tb.Helper()
+
+	select {
+	case m := <-consumer.Messages():
+		require.NotNil(tb, m)
+
+		return m
+	case <-time.After(time.Duration(5*testutils.TimeoutMultiplier) * time.Second):
+		require.Fail(tb, "Timeout while waiting for message to be returned.")
+	}
+
+	return streammsg.Message{}
+}

--- a/streamclient/testing_test.go
+++ b/streamclient/testing_test.go
@@ -1,0 +1,29 @@
+package streamclient_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamclient"
+	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
+	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestMessageFromConsumer(t *testing.T) {
+	t.Parallel()
+
+	store := inmemstore.New()
+	producer, closer := inmemclient.TestProducer(t, store)
+	defer closer()
+
+	producer.Messages() <- streammsg.TestMessage(t, "hello", "world")
+
+	consumer, closer := inmemclient.TestConsumer(t, store)
+	defer closer()
+
+	message := streamclient.TestMessageFromConsumer(t, consumer)
+
+	assert.Equal(t, "hello", string(message.Key))
+	assert.Equal(t, "world", string(message.Value))
+}

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -17,21 +17,27 @@ import (
 // these options can be passed into the new consumer to determine its behavior.
 // If the consumer only has to support a single implementation of the interface,
 // then all other configuration values can be ignored.
-type Consumer struct {
+type Consumer struct { // nolint:malign
 	Inmem          inmemconfig.Consumer
 	Kafka          kafkaconfig.Consumer
 	Pubsub         pubsubconfig.Consumer
 	Standardstream standardstreamconfig.Consumer
 
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger `ignored:"true"`
+	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
+	// stream client based on predefined environment variables. This is enabled by
+	// default, but can be disabled if you want full control over the behavior of
+	// the stream client without any outside influence.
+	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 
 	// HandleInterrupt determines whether the consumer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
 	// these signals manually, this flag disables the automated implementation.
 	HandleInterrupt bool `ignored:"true"`
+
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a no-op logger will be used.
+	Logger zap.Logger `ignored:"true"`
 
 	// Name is the name of the current processor. It is currently only used to
 	// determine the prefix for environment-variable based configuration values.
@@ -40,12 +46,6 @@ type Consumer struct {
 	// is set, then the prefix is "consumer" is used, so you prepend all
 	// environment variables with "CONSUMER_.
 	Name string `ignored:"true"`
-
-	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
-	// stream client based on predefined environment variables. This is enabled by
-	// default, but can be disabled if you want full control over the behavior of
-	// the stream client without any outside influence.
-	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 }
 
 // Producer contains the configuration for all the different consumer that
@@ -53,21 +53,27 @@ type Consumer struct {
 // these options can be passed into the new producer to determine its behavior.
 // If the producer only has to support a single implementation of the interface,
 // then all other configuration values can be ignored.
-type Producer struct {
+type Producer struct { // nolint:malign
 	Inmem          inmemconfig.Producer
 	Kafka          kafkaconfig.Producer
 	Pubsub         pubsubconfig.Producer
 	Standardstream standardstreamconfig.Producer
 
-	// Logger is the configurable logger instance to log messages. If left
-	// undefined, a no-op logger will be used.
-	Logger zap.Logger `ignored:"true"`
+	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
+	// stream client based on predefined environment variables. This is enabled by
+	// default, but can be disabled if you want full control over the behavior of
+	// the stream client without any outside influence.
+	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 
 	// HandleInterrupt determines whether the producer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
 	// these signals manually, this flag disables the automated implementation.
 	HandleInterrupt bool `ignored:"true"`
+
+	// Logger is the configurable logger instance to log messages. If left
+	// undefined, a no-op logger will be used.
+	Logger zap.Logger `ignored:"true"`
 
 	// Name is the name of the current processor. It is currently only used to
 	// determine the prefix for environment-variable based configuration values.
@@ -76,12 +82,6 @@ type Producer struct {
 	// is set, then the prefix is "producer" is used, so you prepend all
 	// environment variables with "PRODUCER_.
 	Name string `ignored:"true"`
-
-	// AllowEnvironmentBasedConfiguration allows you to disable configuring the
-	// stream client based on predefined environment variables. This is enabled by
-	// default, but can be disabled if you want full control over the behavior of
-	// the stream client without any outside influence.
-	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.

--- a/streamconfig/kafkaconfig/testing.go
+++ b/streamconfig/kafkaconfig/testing.go
@@ -13,7 +13,7 @@ var TestBrokerAddress = "127.0.0.1:9092"
 
 // TestConsumer returns a kafkaconfig.Consumer struct with its options tweaked
 // for testing purposes.
-func TestConsumer(tb testing.TB) Consumer {
+func TestConsumer(_ testing.TB) Consumer {
 	config := ConsumerDefaults
 
 	config.Brokers = []string{TestBrokerAddress}

--- a/streamutils/testutils/testing.go
+++ b/streamutils/testutils/testing.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"regexp"
 	"strings"
@@ -43,5 +44,5 @@ func Random(tb testing.TB) string {
 	rand.Seed(time.Now().Unix())
 	name := strings.Replace(tb.Name(), "/", "_", -1)
 	name = validRandomName.FindString(name)
-	return fmt.Sprintf("%s-%d", name, rand.Intn(1000000))
+	return fmt.Sprintf("%s-%d", name, rand.Intn(math.MaxInt64))
 }


### PR DESCRIPTION
Some tweaks and fixes, continuing working through some TODO's before releasing the next version.

- [x] Update references to kafkaconfig.TestBrokerAddress
- [x] Update reference to streamclient.TestMessageFromConsumer
- [x] Improve timeout functionality in tests
- [x] Ignore errors returned by logger.Sync()
- [x] Call logger.Sync() when closing all streamclients
- [x] Move kafkaclient.TestMessageFromConsumer to streamclient
- [x] Sort streamconfig.Consumer/Producer fields
- [x] Use MaxInt64 to randomize string
- [x] Simplify kafkaclient.TestConsumerConfig
- [x] Fix several gometalinter warnings