### PR TITLE
Introduce `Errors()` channel for consumers and producers

### DIFF
--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -13,6 +13,10 @@ type Consumer interface {
 	// The channel returns each message as a `streammsg.Message` value object.
 	Messages() <-chan streammsg.Message
 
+	// Errors is a read-only channel on which the consumer delivers any errors
+	// that occurred while consuming from the stream.
+	Errors() <-chan error
+
 	// Ack can be used to acknowledge that a message was processed and should not
 	// be delivered again.
 	Ack(streammsg.Message) error

--- a/stream/consumermock.go
+++ b/stream/consumermock.go
@@ -9,6 +9,7 @@ import (
 type ConsumerMock struct {
 	Configuration streamconfig.Consumer
 	MessagesChan  chan streammsg.Message
+	ErrorsChan    chan error
 }
 
 var _ Consumer = (*ConsumerMock)(nil)
@@ -16,6 +17,11 @@ var _ Consumer = (*ConsumerMock)(nil)
 // Messages implements the Consumer interface for ConsumerMock.
 func (c *ConsumerMock) Messages() <-chan streammsg.Message {
 	return c.MessagesChan
+}
+
+// Errors implements the Consumer interface for ConsumerMock.
+func (c *ConsumerMock) Errors() <-chan error {
+	return c.ErrorsChan
 }
 
 // Ack implements the Consumer interface for ConsumerMock.
@@ -31,6 +37,7 @@ func (c *ConsumerMock) Nack(_ streammsg.Message) error {
 // Close implements the Consumer interface for ConsumerMock.
 func (c *ConsumerMock) Close() error {
 	close(c.MessagesChan)
+	close(c.ErrorsChan)
 	return nil
 }
 

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -13,6 +13,10 @@ type Producer interface {
 	// The channel accepts `streammsg.Message` value objects.
 	Messages() chan<- streammsg.Message
 
+	// Errors is a read-only channel on which the producer delivers any errors
+	// that occurred while producing to the stream.
+	Errors() <-chan error
+
 	// Close closes the producer. After calling this method, the producer is no
 	// longer in a usable state, and subsequent method calls can result in
 	// panics.

--- a/stream/producermock.go
+++ b/stream/producermock.go
@@ -9,6 +9,7 @@ import (
 type ProducerMock struct {
 	Configuration streamconfig.Producer
 	MessagesChan  chan streammsg.Message
+	ErrorsChan    chan error
 }
 
 var _ Producer = (*ProducerMock)(nil)
@@ -18,9 +19,15 @@ func (p *ProducerMock) Messages() chan<- streammsg.Message {
 	return p.MessagesChan
 }
 
+// Errors implements the Producer interface for ProducerMock.
+func (p *ProducerMock) Errors() <-chan error {
+	return p.ErrorsChan
+}
+
 // Close implements the Producer interface for ProducerMock.
 func (p *ProducerMock) Close() error {
 	close(p.MessagesChan)
+	close(p.ErrorsChan)
 	return nil
 }
 

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -122,6 +122,38 @@ func TestConsumer_Messages_PerMessageMemoryAllocation(t *testing.T) {
 	}
 }
 
+func TestConsumer_Errors(t *testing.T) {
+	t.Parallel()
+
+	options := func(c *streamconfig.Consumer) {
+		c.HandleErrors = true
+	}
+
+	consumer, closer := inmemclient.TestConsumer(t, nil, options)
+	defer closer()
+
+	err := <-consumer.Errors()
+	require.Error(t, err)
+	assert.Equal(t, "unable to manually consume errors while HandleErrors is true", err.Error())
+}
+
+func TestConsumer_Errors_Manual(t *testing.T) {
+	t.Parallel()
+
+	options := func(c *streamconfig.Consumer) {
+		c.HandleErrors = false
+	}
+
+	consumer, closer := inmemclient.TestConsumer(t, nil, options)
+	defer closer()
+
+	select {
+	case err := <-consumer.Errors():
+		t.Fatalf("expected no error, got %s", err.Error())
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
 func TestConsumer_Close(t *testing.T) {
 	t.Parallel()
 

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamcore"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
@@ -18,6 +19,7 @@ type Producer struct {
 
 	logger   *zap.Logger
 	wg       sync.WaitGroup
+	errors   chan error
 	messages chan<- streammsg.Message
 	once     *sync.Once
 }
@@ -36,6 +38,17 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	// add one to the WaitGroup. We remove this one only after all writes (below)
 	// are completed and the write channel is closed.
 	producer.wg.Add(1)
+
+	// We start a goroutine to listen for errors on the errors channel, and log a
+	// fatal error (terminating the application in the process) when an error is
+	// received.
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag. If the auto-error functionality is disabled, the user
+	// needs to manually listen to the `Errors()` channel and act accordingly.
+	if producer.c.HandleErrors {
+		go streamcore.HandleErrors(producer.errors, producer.logger.Fatal)
+	}
 
 	// We listen to the produce channel in a goroutine. Every message delivered to
 	// this producer gets stored in the inmem store. If the producer is closed,
@@ -61,6 +74,12 @@ func (p *Producer) Messages() chan<- streammsg.Message {
 	return p.messages
 }
 
+// Errors returns the read channel for the errors that are returned by the
+// stream.
+func (p *Producer) Errors() <-chan error {
+	return streamcore.ErrorsChan(p.errors, p.c.HandleErrors)
+}
+
 // Close closes the producer connection. This function blocks until all messages
 // still in the channel have been processed, and the channel is properly closed.
 func (p *Producer) Close() error {
@@ -70,6 +89,10 @@ func (p *Producer) Close() error {
 		// Wait until the WaitGroup counter is zero. This makes sure we block the
 		// close call until all messages have been delivered, to prevent data-loss.
 		p.wg.Wait()
+
+		// At this point, no more errors are expected, so we can close the errors
+		// channel.
+		close(p.errors)
 
 		// Let's flush all logs still in the buffer, since this producer is no
 		// longer useful after this point. We ignore any errors returned by sync, as
@@ -102,6 +125,7 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 	producer := &Producer{
 		c:        config,
 		logger:   &config.Logger,
+		errors:   make(chan error),
 		messages: ch,
 		once:     &sync.Once{},
 	}

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamcore"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -20,6 +22,7 @@ type Producer struct {
 
 	logger   *zap.Logger
 	wg       sync.WaitGroup
+	errors   chan error
 	messages chan<- streammsg.Message
 }
 
@@ -37,6 +40,17 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	// add one to the WaitGroup. We remove this one only after all writes (below)
 	// are completed and the write channel is closed.
 	producer.wg.Add(1)
+
+	// We start a goroutine to listen for errors on the errors channel, and log a
+	// fatal error (terminating the application in the process) when an error is
+	// received.
+	//
+	// This functionality is enabled by default, but can be disabled through a
+	// configuration flag. If the auto-error functionality is disabled, the user
+	// needs to manually listen to the `Errors()` channel and act accordingly.
+	if producer.c.HandleErrors {
+		go streamcore.HandleErrors(producer.errors, producer.logger.Fatal)
+	}
 
 	// We listen to the produce channel in a goroutine. For every message
 	// delivered to this producer we add a newline (if missing), and send the
@@ -63,6 +77,12 @@ func (p *Producer) Messages() chan<- streammsg.Message {
 	return p.messages
 }
 
+// Errors returns the read channel for the errors that are returned by the
+// stream.
+func (p *Producer) Errors() <-chan error {
+	return streamcore.ErrorsChan(p.errors, p.c.HandleErrors)
+}
+
 // Close closes the producer connection. This function blocks until all messages
 // still in the channel have been processed, and the channel is properly closed.
 func (p *Producer) Close() error {
@@ -71,6 +91,10 @@ func (p *Producer) Close() error {
 	// Wait until the WaitGroup counter is zero. This makes sure we block the
 	// close call until all messages have been delivered, to prevent data-loss.
 	p.wg.Wait()
+
+	// At this point, no more errors are expected, so we can close the errors
+	// channel.
+	close(p.errors)
 
 	// Let's flush all logs still in the buffer, since this producer is no
 	// longer useful after this point. We ignore any errors returned by sync, as
@@ -99,11 +123,7 @@ func (p *Producer) produce(ch <-chan streammsg.Message) {
 
 		_, err := p.c.Standardstream.Writer.Write(message)
 		if err != nil {
-			p.logger.Fatal(
-				"Unable to write message to stream.",
-				zap.ByteString("messageValue", message),
-				zap.Error(err),
-			)
+			p.errors <- errors.Wrap(err, "unable to write message to stream")
 		}
 	}
 }
@@ -117,6 +137,7 @@ func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Produce
 	producer := &Producer{
 		c:        config,
 		logger:   &config.Logger,
+		errors:   make(chan error),
 		messages: ch,
 	}
 

--- a/streamclient/standardstreamclient/testing.go
+++ b/streamclient/standardstreamclient/testing.go
@@ -49,14 +49,14 @@ func TestConsumer(tb testing.TB, r io.ReadCloser, options ...func(c *streamconfi
 //
 // The return value is the producer, and a function that should be deferred to
 // clean up resources.
-func TestProducer(tb testing.TB, w io.Writer) (stream.Producer, func()) {
+func TestProducer(tb testing.TB, w io.Writer, options ...func(c *streamconfig.Producer)) (stream.Producer, func()) {
 	tb.Helper()
 
-	options := func(c *streamconfig.Producer) {
+	options = append(options, func(c *streamconfig.Producer) {
 		c.Standardstream.Writer = w
-	}
+	})
 
-	producer, err := NewProducer(options)
+	producer, err := NewProducer(options...)
 	require.NoError(tb, err)
 
 	return producer, func() { require.NoError(tb, producer.Close()) }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -29,6 +29,13 @@ type Consumer struct { // nolint:malign
 	// the stream client without any outside influence.
 	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 
+	// HandleErrors determines whether the consumer should handle any stream
+	// errors by itself, and terminate the application if any error occurs. This
+	// defaults to true. If manually set to false, the `Errors()` channel needs to
+	// be consumed manually, and any appropriate action needs to be taken when an
+	// errors occurs, otherwise the consumer will get stuck once an error occurs.
+	HandleErrors bool `ignored:"true"`
+
 	// HandleInterrupt determines whether the consumer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
@@ -65,6 +72,13 @@ type Producer struct { // nolint:malign
 	// the stream client without any outside influence.
 	AllowEnvironmentBasedConfiguration bool `ignored:"true"`
 
+	// HandleErrors determines whether the consumer should handle any stream
+	// errors by itself, and terminate the application if any error occurs. This
+	// defaults to true. If manually set to false, the `Errors()` channel needs to
+	// be consumed manually, and any appropriate action needs to be taken when an
+	// errors occurs, otherwise the consumer will get stuck once an error occurs.
+	HandleErrors bool `ignored:"true"`
+
 	// HandleInterrupt determines whether the producer should close itself
 	// gracefully when an interrupt signal (^C) is received. This defaults to true
 	// to increase first-time ease-of-use, but if the application wants to handle
@@ -87,6 +101,7 @@ type Producer struct { // nolint:malign
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
 	Logger:          *zap.NewNop(),
+	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "consumer",
 	AllowEnvironmentBasedConfiguration: true,
@@ -95,6 +110,7 @@ var ConsumerDefaults = Consumer{
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
 	Logger:          *zap.NewNop(),
+	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "producer",
 	AllowEnvironmentBasedConfiguration: true,

--- a/streamconfig/testing.go
+++ b/streamconfig/testing.go
@@ -25,6 +25,7 @@ func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) C
 		c.Standardstream = standardstreamconfig.Consumer{}
 		c.Logger = zap.Logger{}
 		c.HandleInterrupt = false
+		c.HandleErrors = false
 		c.Name = ""
 		c.AllowEnvironmentBasedConfiguration = false
 	}
@@ -70,6 +71,7 @@ func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) P
 		p.Standardstream = standardstreamconfig.Producer{}
 		p.Logger = zap.Logger{}
 		p.HandleInterrupt = false
+		p.HandleErrors = false
 		p.Name = ""
 		p.AllowEnvironmentBasedConfiguration = false
 	}

--- a/streamcore/error.go
+++ b/streamcore/error.go
@@ -1,0 +1,36 @@
+package streamcore
+
+import (
+	"errors"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// HandleErrors listens to the provided channel, and triggers a fatal error when
+// any error is received.
+func HandleErrors(ch chan error, logger func(msg string, fields ...zapcore.Field)) {
+	for err := range ch {
+		if err == nil {
+			continue
+		}
+
+		logger("Error received from streamclient.", zap.Error(err))
+	}
+}
+
+// ErrorsChan returns the passed in errors channel, unless `disabled` is set to
+// `true`, in which case a temporary new errors channel is created, and an error
+// is returned, indicating that the errors channel cannot be used with the
+// current streamconfig.
+func ErrorsChan(ch chan error, disabled bool) chan error {
+	if disabled {
+		errs := make(chan error, 1)
+		defer close(errs)
+
+		errs <- errors.New("unable to manually consume errors while HandleErrors is true")
+		return errs
+	}
+
+	return ch
+}

--- a/streamcore/error_test.go
+++ b/streamcore/error_test.go
@@ -1,0 +1,113 @@
+package streamcore_test
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blendle/go-streamprocessor/streamcore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+type StubLogger struct {
+	logs  []string
+	mutex *sync.Mutex
+}
+
+func (l *StubLogger) Log(msg string, fields ...zapcore.Field) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	var log []string
+
+	log = append(log, msg)
+	for i := range fields {
+		if err, ok := fields[i].Interface.(error); ok {
+			log = append(log, err.Error())
+		}
+	}
+
+	l.logs = append(l.logs, strings.Join(log, " "))
+}
+
+func (l *StubLogger) Logs() []string {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	return l.logs
+}
+
+func TestHandleErrors(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		errs    []error
+		results []string
+	}{
+		"single": {
+			[]error{errors.New("panic!")},
+			[]string{"Error received from streamclient. panic!"},
+		},
+		"multiple": {
+			[]error{errors.New("panic!"), errors.New("seriously!")},
+			[]string{
+				"Error received from streamclient. panic!",
+				"Error received from streamclient. seriously!",
+			},
+		},
+		"skip nil": {
+			[]error{nil, errors.New("seriously!")},
+			[]string{"Error received from streamclient. seriously!"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := &StubLogger{make([]string, 0), &sync.Mutex{}}
+			ch := make(chan error, len(tt.errs))
+			defer close(ch)
+
+			for _, err := range tt.errs {
+				ch <- err
+			}
+
+			go streamcore.HandleErrors(ch, logger.Log)
+			time.Sleep(5 * time.Millisecond)
+
+			require.Len(t, logger.Logs(), len(tt.results))
+
+			for i, s := range tt.results {
+				assert.Equal(t, s, logger.Logs()[i])
+			}
+		})
+	}
+}
+
+func TestErrorsChan(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		disabled bool
+		errors   int
+	}{
+		"disabled": {
+			true,
+			1,
+		},
+		"enabled": {
+			false,
+			0,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ch := streamcore.ErrorsChan(make(chan error), tt.disabled)
+			assert.Len(t, ch, tt.errors)
+		})
+	}
+}


### PR DESCRIPTION
Every producer and consumer now has its own internal errors channel to
which any errors are delivered that occur during consuming or producing
messages from or to the stream.

By default, this errors channel is consumed internally, and any error
received on the channel is logged on a "fatal" level, indicating the
message is sent to stderr, and the application exits with status code 1.

This default behavior can be changed, by setting the `HandleErrors`
configuration flag to false, indicating that the consumer or producer
should not listen to the errors channel. When configured like this, the
processor application itself is required to listen to any errors being
sent to the `Errors()` channel, and the processor should dictate what to
do with each error.

For now, the errors are delivered in raw form. In the future, this might
be changed to allow the consumer to more easily distinguish between the
different error types returned on the channel.