### PR TITLE
Improve Interrupt signal handling + testing

### DIFF
--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -1,13 +1,13 @@
 package inmemclient
 
 import (
+	"os"
 	"sync"
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamcore"
 	"github.com/blendle/go-streamprocessor/streammsg"
-	"github.com/blendle/go-streamprocessor/streamutils"
 	"go.uber.org/zap"
 )
 
@@ -21,6 +21,7 @@ type Producer struct {
 	wg       sync.WaitGroup
 	errors   chan error
 	messages chan<- streammsg.Message
+	signals  chan os.Signal
 	once     *sync.Once
 }
 
@@ -63,7 +64,8 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if producer.c.HandleInterrupt {
-		go streamutils.HandleInterrupts(producer.Close, producer.logger)
+		producer.signals = make(chan os.Signal, 1)
+		go streamcore.HandleInterrupts(producer.signals, producer.Close, producer.logger)
 	}
 
 	return producer, nil
@@ -98,6 +100,9 @@ func (p *Producer) Close() error {
 		// longer useful after this point. We ignore any errors returned by sync, as
 		// it is known to return unexpected errors. See: https://git.io/vpJFk
 		_ = p.logger.Sync() // nolint: gas
+
+		// Finally, close the signals channel, as it's no longer needed
+		close(p.signals)
 	})
 
 	return nil

--- a/streamcore/interrupt.go
+++ b/streamcore/interrupt.go
@@ -1,4 +1,4 @@
-package streamutils
+package streamcore
 
 import (
 	"os"
@@ -12,11 +12,13 @@ import (
 // closer function once received. It has a built-in timeout capability to force
 // terminate the application when the closer takes too long to close, or returns
 // an error during closing.
-func HandleInterrupts(closer func() error, logger *zap.Logger) {
-	signals := make(chan os.Signal, 1)
+func HandleInterrupts(signals chan os.Signal, closer func() error, logger *zap.Logger) {
 	signal.Notify(signals, os.Interrupt)
 
-	s := <-signals
+	s, ok := <-signals
+	if !ok {
+		return
+	}
 
 	logger.Info(
 		"Got interrupt signal, cleaning up. Use ^C again to exit immediately.",

--- a/streamcore/interrupt_test.go
+++ b/streamcore/interrupt_test.go
@@ -1,0 +1,44 @@
+package streamcore_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/blendle/go-streamprocessor/streamcore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestHandleInterrupts(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("BE_TESTING_FATAL") == "1" {
+		ch := make(chan os.Signal)
+		logger, err := zap.NewDevelopment()
+		require.NoError(t, err)
+
+		fn := func() error {
+			println("closed!")
+			return nil
+		}
+
+		go streamcore.HandleInterrupts(ch, fn, logger)
+		ch <- os.Interrupt
+
+		time.Sleep(10 * time.Millisecond)
+
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+	cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+
+	out, err := cmd.CombinedOutput()
+	require.Nil(t, err, "output received: %s", string(out))
+
+	assert.Contains(t, string(out), "Got interrupt signal")
+	assert.Contains(t, string(out), "closed!")
+}


### PR DESCRIPTION
- [x] moved the `HandleInterrupts` function from `streamutils` to `streamcore`
- [x] increase test coverage of `HandleInterrupts`
- [x] correctly close interrupt signal channel on consumer/producer closing
