### PR TITLE
Minor improvements to some tests & code

### DIFF
--- a/script/test
+++ b/script/test
@@ -25,6 +25,9 @@ script/tests/gometalinter
 echo "==      go-test"
 script/tests/go-test "$@"
 
+echo "==      go-test-cover"
+script/tests/go-test-cover "$@"
+
 echo "==      go-test-race"
 script/tests/go-test-race "$@"
 

--- a/script/tests/go-test
+++ b/script/tests/go-test
@@ -1,9 +1,22 @@
 #!/bin/sh
 
-# script/tests/go-test-race: Run benchmark tests
+# script/tests/go-test: Run tests
 
 set -e
 
 cd "$(dirname "$0")/../.."
 
-go test ${@:-./...}
+if [ -z "$*" ] && ! nc -z -G1 127.0.0.1 9092 2>/dev/null; then
+  echo >&2 "No response received from 127.0.0.1:9092." \
+           "Unable to run integration tests."
+  echo >&2
+  echo >&2 "Running script with \"-short ./...\" arguments."
+  echo >&2
+  echo >&2 "To run integration tests, first run \"docker-compose up\"."
+  echo >&2
+
+  $0 -short ./...
+  exit $?
+fi
+
+go test "${@:-./...}"

--- a/script/tests/go-test-bench
+++ b/script/tests/go-test-bench
@@ -6,4 +6,17 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-go test -bench . -run='^$' -benchtime=4s -benchmem ${@:-./...}
+if [ -z "$*" ] && ! nc -z -G1 127.0.0.1 9092 2>/dev/null; then
+  echo >&2 "No response received from 127.0.0.1:9092." \
+           "Unable to run integration tests."
+  echo >&2
+  echo >&2 "Running script with \"-short ./...\" arguments."
+  echo >&2
+  echo >&2 "To run integration tests, first run \"docker-compose up\"."
+  echo >&2
+
+  $0 -short ./...
+  exit $?
+fi
+
+go test -bench . -benchmem -benchtime=4s -run '^$' "${@:-./...}"

--- a/script/tests/go-test-cover
+++ b/script/tests/go-test-cover
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# script/tests/go-test-cover: Validate test coverage
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+if [ -z "$*" ] && ! nc -z -G1 127.0.0.1 9092 2>/dev/null; then
+  echo >&2 "No response received from 127.0.0.1:9092." \
+           "Unable to run integration tests."
+  echo >&2
+  echo >&2 "Running script with \"-short ./...\" arguments."
+  echo >&2
+  echo >&2 "To run integration tests, first run \"docker-compose up\"."
+  echo >&2
+
+  $0 -short ./...
+  exit $?
+fi
+
+min="80"
+tmp=$(mktemp)
+go test -cover "${@:-./...}" -coverprofile="$tmp" >/dev/null
+coverage="$(go tool cover -func="$tmp")"
+percent="$(echo "$coverage" | tail -n1 | awk '{print $3}' | sed -e 's/^\([0-9]*\).*$/\1/g')"
+
+if [ "$percent" -lt "$min" ]; then
+  >&2 echo "$coverage"
+  >&2 echo
+  >&2 echo "FAILED: test coverage $percent is below configured minimum: $min"
+  >&2 echo
+  >&2 echo "Run the following command for more insights:"
+  >&2 echo
+  >&2 echo "  go test -coverprofile=coverage.out ${*:-./...}; go tool cover -html=coverage.out"
+
+  exit 1
+fi

--- a/script/tests/go-test-race
+++ b/script/tests/go-test-race
@@ -1,9 +1,22 @@
 #!/bin/sh
 
-# script/tests/go-test-race: Run benchmark tests
+# script/tests/go-test-race: Run tests with race checker
 
 set -e
 
 cd "$(dirname "$0")/../.."
 
-go test -cpu=1,2,4 -race ${@:-./...}
+if [ -z "$*" ] && ! nc -z -G1 127.0.0.1 9092 2>/dev/null; then
+  echo >&2 "No response received from 127.0.0.1:9092." \
+           "Unable to run integration tests."
+  echo >&2
+  echo >&2 "Running script with \"-short ./...\" arguments."
+  echo >&2
+  echo >&2 "To run integration tests, first run \"docker-compose up\"."
+  echo >&2
+
+  $0 -short ./...
+  exit $?
+fi
+
+go test -cpu=1,2,4 -race "${@:-./...}"

--- a/script/tests/godog
+++ b/script/tests/godog
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# script/tests/go-test-race: Run benchmark tests
-
-set -ae
-
-cd "$(dirname "$0")/../.."
-
-godog --random --strict --tags ~@wip "$@"

--- a/script/tests/gometalinter
+++ b/script/tests/gometalinter
@@ -6,17 +6,17 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-matches=$(grep \
-  --ignore-case \
-  --recursive \
-  --exclude-dir vendor \
-  '^// [a-z]* \.\.\.$' . || true)
+[ -z "$CI" ] || cd "$GOPATH/src/github.com/blendle/stream-processor-pipe"
+
+matches=$(find . \( -name vendor -prune \) \
+  -o \( -type f -name '*' \) \
+  -exec grep -i '^// [a-z]* \.\.\.$' {} \; || true)
 
 if [ -n "$matches" ]; then
-  echo >&2 "Invalid code comments detected:"
-  echo >&2
-  echo >&2 "$matches"
-  echo >&2
+  >&2 echo "Invalid code comments detected:"
+  >&2 echo
+  >&2 echo "$matches"
+  >&2 echo
   exit 1
 fi
 
@@ -28,8 +28,9 @@ gometalinter \
   --vendored-linters \
   --enable-all \
   --line-length=100 \
+  --cyclo-over=11 \
   --disable=dupl \
   --linter='lll:lll -e func -g -l {maxlinelength}:PATH:LINE:MESSAGE' \
   --linter='test:go test -short:PATH:LINE:MESSAGE' \
   --linter='testify:go test -short:PATH:LINE:MESSAGE' \
-  ${@:-./...}
+  "${@:-./...}"

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -154,6 +154,24 @@ func TestConsumer_Errors_Manual(t *testing.T) {
 	}
 }
 
+func TestConsumer_Ack(t *testing.T) {
+	t.Parallel()
+
+	consumer, closer := inmemclient.TestConsumer(t, nil)
+	defer closer()
+
+	assert.Nil(t, consumer.Ack(streammsg.Message{}))
+}
+
+func TestConsumer_Nack(t *testing.T) {
+	t.Parallel()
+
+	consumer, closer := inmemclient.TestConsumer(t, nil)
+	defer closer()
+
+	assert.Nil(t, consumer.Nack(streammsg.Message{}))
+}
+
 func TestConsumer_Close(t *testing.T) {
 	t.Parallel()
 

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -175,7 +175,11 @@ func (c *Consumer) consume() {
 			c.logger.Info("Received quit signal. Exiting consumer.")
 
 			return
-		case event := <-c.kafka.Events():
+		case event, ok := <-c.kafka.Events():
+			if !ok {
+				return
+			}
+
 			switch e := event.(type) {
 
 			// If we received an `AssignedPartitions` event, we need to make sure we
@@ -273,7 +277,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 		kafka:    kafkaconsumer,
 		errors:   make(chan error),
 		messages: make(chan streammsg.Message),
-		quit:     make(chan bool),
+		quit:     make(chan bool, 1),
 		once:     &sync.Once{},
 	}
 

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -241,7 +241,7 @@ func TestIntegrationConsumer_Ack(t *testing.T) {
 	assert.Equal(t, int64(2), int64(offsets[0].Offset))
 }
 
-func TestIntegrationMessage_Ack_WithClosedConsumer(t *testing.T) {
+func TestIntegrationConsumer_Ack_WithClosedConsumer(t *testing.T) {
 	t.Parallel()
 	testutils.Integration(t)
 

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -257,6 +257,16 @@ func TestIntegrationMessage_Ack_WithClosedConsumer(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestIntegrationConsumer_Nack(t *testing.T) {
+	t.Parallel()
+	testutils.Integration(t)
+
+	consumer, closer := kafkaclient.TestConsumer(t, testutils.Random(t))
+	defer closer()
+
+	assert.Nil(t, consumer.Nack(streammsg.Message{}))
+}
+
 func BenchmarkIntegrationConsumer_Messages(b *testing.B) {
 	testutils.Integration(b)
 

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -141,7 +141,7 @@ func TestOffsets(tb testing.TB, message streammsg.Message) []kafka.TopicPartitio
 	defer closer()
 
 	tp := []kafka.TopicPartition{*streammsg.MessageOpqaue(&message).(opaque).toppar}
-	offsets, err := consumer.Committed(tp, 2000*testutils.TimeoutMultiplier)
+	offsets, err := consumer.Committed(tp, 2000)
 	require.NoError(tb, err)
 
 	return offsets

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -3,6 +3,7 @@ package kafkaclient_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
@@ -82,6 +83,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
 		"produce.offset.report": false,
 	}
+
 	producer, err := kafka.NewProducer(config)
 	require.NoError(t, err)
 
@@ -101,7 +103,10 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 
 	consumer, err := kafkaclient.NewConsumer(options)
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, consumer.Close()) }()
+	defer func() {
+		time.Sleep(100 * time.Millisecond)
+		assert.NoError(t, consumer.Close())
+	}()
 
 	message := streamclient.TestMessageFromConsumer(t, consumer)
 

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -179,6 +180,26 @@ func TestConsumer_Errors_Manual(t *testing.T) {
 		t.Fatalf("expected no error, got %s", err.Error())
 	case <-time.After(10 * time.Millisecond):
 	}
+}
+
+func TestConsumer_Ack(t *testing.T) {
+	t.Parallel()
+
+	b := standardstreamclient.TestBuffer(t)
+	consumer, closer := standardstreamclient.TestConsumer(t, b)
+	defer closer()
+
+	assert.Nil(t, consumer.Ack(streammsg.Message{}))
+}
+
+func TestConsumer_Nack(t *testing.T) {
+	t.Parallel()
+
+	b := standardstreamclient.TestBuffer(t)
+	consumer, closer := standardstreamclient.TestConsumer(t, b)
+	defer closer()
+
+	assert.Nil(t, consumer.Nack(streammsg.Message{}))
 }
 
 func BenchmarkConsumer_Messages(b *testing.B) {

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -142,8 +142,8 @@ func TestConsumer_Messages_ScannerError(t *testing.T) {
 	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
 	cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
 
-	_, err := cmd.CombinedOutput()
-	require.NotNil(t, err)
+	out, err := cmd.CombinedOutput()
+	require.NotNil(t, err, "output received: %s", string(out))
 
 	assert.False(t, err.(*exec.ExitError).Success())
 }

--- a/streamclient/testing.go
+++ b/streamclient/testing.go
@@ -21,7 +21,7 @@ func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) streammsg.
 		require.NotNil(tb, m)
 
 		return m
-	case <-time.After(time.Duration(5*testutils.TimeoutMultiplier) * time.Second):
+	case <-time.After(time.Duration(3*testutils.TimeoutMultiplier) * time.Second):
 		require.Fail(tb, "Timeout while waiting for message to be returned.")
 	}
 

--- a/streamclient/testing_test.go
+++ b/streamclient/testing_test.go
@@ -1,13 +1,17 @@
 package streamclient_test
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTestMessageFromConsumer(t *testing.T) {
@@ -19,11 +23,40 @@ func TestTestMessageFromConsumer(t *testing.T) {
 
 	producer.Messages() <- streammsg.TestMessage(t, "hello", "world")
 
-	consumer, closer := inmemclient.TestConsumer(t, store)
+	opts := func(c *streamconfig.Consumer) {
+		c.Inmem.ConsumeOnce = false
+	}
+
+	consumer, closer := inmemclient.TestConsumer(t, store, opts)
 	defer closer()
 
 	message := streamclient.TestMessageFromConsumer(t, consumer)
 
 	assert.Equal(t, "hello", string(message.Key))
 	assert.Equal(t, "world", string(message.Value))
+}
+
+func TestTestMessageFromConsumer_Timeout(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("BE_TESTING_FATAL") == "1" {
+		opts := func(c *streamconfig.Consumer) {
+			c.Inmem.ConsumeOnce = false
+		}
+
+		consumer, closer := inmemclient.TestConsumer(t, nil, opts)
+		defer closer()
+
+		_ = streamclient.TestMessageFromConsumer(t, consumer)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+	cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+
+	out, err := cmd.CombinedOutput()
+	require.NotNil(t, err, "output received: %s", string(out))
+
+	assert.False(t, err.(*exec.ExitError).Success())
+	assert.Contains(t, string(out), "Timeout while waiting for message to be returned.")
 }

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -117,18 +117,20 @@ var ProducerDefaults = Producer{
 }
 
 // Usage calls the usage() function and returns a byte array.
+// Usage returns a byte array with a table-based explanation on how to set the
+// configuration values using environment variables. This can be used to explain
+// usage details to the user of the application.
 func (c Consumer) Usage() []byte {
 	return usage(c.Name, c)
 }
 
-// Usage calls the usage() function and returns a byte array.
+// Usage returns a byte array with a table-based explanation on how to set the
+// configuration values using environment variables. This can be used to explain
+// usage details to the user of the application.
 func (p Producer) Usage() []byte {
 	return usage(p.Name, p)
 }
 
-// usage returns a byte array with a table-based explanation on how to set the
-// configuration values using environment variables. This can be used to explain
-// usage details to the user of the application.
 func usage(name string, inf interface{}) []byte {
 	var err error
 	b := &bytes.Buffer{}

--- a/streamconfig/kafkaconfig/types_test.go
+++ b/streamconfig/kafkaconfig/types_test.go
@@ -1,0 +1,264 @@
+package kafkaconfig_test
+
+import (
+	"testing"
+
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebug_Set(t *testing.T) {
+	var tests = map[string]struct {
+		in  string
+		out kafkaconfig.Debug
+	}{
+		"empty": {
+			"",
+			kafkaconfig.Debug{},
+		},
+
+		"all": {
+			"all",
+			kafkaconfig.Debug{All: true},
+		},
+
+		"broker": {
+			"broker",
+			kafkaconfig.Debug{Broker: true},
+		},
+
+		"cgrp": {
+			"cgrp",
+			kafkaconfig.Debug{CGRP: true},
+		},
+
+		"consumer": {
+			"consumer",
+			kafkaconfig.Debug{Consumer: true},
+		},
+
+		"feature": {
+			"feature",
+			kafkaconfig.Debug{Feature: true},
+		},
+
+		"fetch": {
+			"fetch",
+			kafkaconfig.Debug{Fetch: true},
+		},
+
+		"generic": {
+			"generic",
+			kafkaconfig.Debug{Generic: true},
+		},
+
+		"interceptor": {
+			"interceptor",
+			kafkaconfig.Debug{Interceptor: true},
+		},
+
+		"metadata": {
+			"metadata",
+			kafkaconfig.Debug{Metadata: true},
+		},
+
+		"msg": {
+			"msg",
+			kafkaconfig.Debug{Msg: true},
+		},
+
+		"plugin": {
+			"plugin",
+			kafkaconfig.Debug{Plugin: true},
+		},
+
+		"protocol": {
+			"protocol",
+			kafkaconfig.Debug{Protocol: true},
+		},
+
+		"queue": {
+			"queue",
+			kafkaconfig.Debug{Queue: true},
+		},
+
+		"security": {
+			"security",
+			kafkaconfig.Debug{Security: true},
+		},
+
+		"topic": {
+			"topic",
+			kafkaconfig.Debug{Topic: true},
+		},
+
+		"combination": {
+			"queue,topic,msg",
+			kafkaconfig.Debug{Queue: true, Topic: true, Msg: true},
+		},
+
+		"combination with all": {
+			"queue,all,topic,msg",
+			kafkaconfig.Debug{All: true},
+		},
+
+		"unknown": {
+			"unknown",
+			kafkaconfig.Debug{},
+		},
+
+		"combination with unknown": {
+			"metadata,unknown,feature",
+			kafkaconfig.Debug{Metadata: true, Feature: true},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := &kafkaconfig.Debug{}
+
+			err := d.Set(tt.in)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, tt.out, *d)
+		})
+	}
+}
+
+func TestOffset_Set(t *testing.T) {
+	var tests = map[string]struct {
+		in  string
+		out kafkaconfig.Offset
+	}{
+		"empty": {
+			"",
+			"",
+		},
+
+		"beginning": {
+			"beginning",
+			kafkaconfig.OffsetBeginning,
+		},
+
+		"end": {
+			"end",
+			kafkaconfig.OffsetEnd,
+		},
+
+		"unknown": {
+			"unknown",
+			"unknown",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			oo := kafkaconfig.Offset("")
+			o := &oo
+
+			err := o.Set(tt.in)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, tt.out, *o)
+		})
+	}
+}
+
+func TestProtocol_Set(t *testing.T) {
+	var tests = map[string]struct {
+		in  string
+		out kafkaconfig.Protocol
+	}{
+		"empty": {
+			"",
+			"",
+		},
+
+		"plaintext": {
+			"plaintext",
+			kafkaconfig.ProtocolPlaintext,
+		},
+
+		"ssl": {
+			"ssl",
+			kafkaconfig.ProtocolSSL,
+		},
+
+		"sasl_plaintext": {
+			"sasl_plaintext",
+			kafkaconfig.ProtocolSASLPlaintext,
+		},
+
+		"sasl_ssl": {
+			"sasl_ssl",
+			kafkaconfig.ProtocolSASLSSL,
+		},
+
+		"unknown": {
+			"unknown",
+			"unknown",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			oo := kafkaconfig.Protocol("")
+			o := &oo
+
+			err := o.Set(tt.in)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, tt.out, *o)
+		})
+	}
+}
+
+func TestCompression_Set(t *testing.T) {
+	var tests = map[string]struct {
+		in  string
+		out kafkaconfig.Compression
+	}{
+		"empty": {
+			"",
+			"",
+		},
+
+		"none": {
+			"none",
+			kafkaconfig.CompressionNone,
+		},
+
+		"gzip": {
+			"gzip",
+			kafkaconfig.CompressionGZIP,
+		},
+
+		"snappy": {
+			"snappy",
+			kafkaconfig.CompressionSnappy,
+		},
+
+		"lz4": {
+			"lz4",
+			kafkaconfig.CompressionLZ4,
+		},
+
+		"unknown": {
+			"unknown",
+			"unknown",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			oo := kafkaconfig.Compression("")
+			o := &oo
+
+			err := o.Set(tt.in)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, tt.out, *o)
+		})
+	}
+}

--- a/streamutils/testutils/testing_test.go
+++ b/streamutils/testutils/testing_test.go
@@ -1,6 +1,7 @@
 package testutils_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
@@ -9,4 +10,14 @@ import (
 
 func TestTimeoutMultiplier(t *testing.T) {
 	assert.Equal(t, 1, testutils.TimeoutMultiplier)
+}
+
+func TestIntegration_Test(t *testing.T) {
+	testutils.Integration(t)
+}
+
+func TestRandom(t *testing.T) {
+	s := testutils.Random(t)
+
+	assert.True(t, strings.HasPrefix(s, "TestRandom-"), s)
 }


### PR DESCRIPTION
- [x] Add missing Ack/Nack tests
- [x] Improve `TestMessageFromConsumer` test coverage
- [x] Add kafkaconfig types tests
- [x] Add `testutils.TestIntegration` and `Random` tests
- [x] Exit consumer loop once kafka client is closed
- [x] Allow calling standardstreamclient Close multiple times
- [x] Minor tests/code tweaks & improvements
- [x] add `go-test-cover` script
- [x] Remove unused `godog` script
- [x] Update all test scripts