### PR TITLE
Move streammsg.Message to stream.Message

### DIFF
--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -1,17 +1,12 @@
 package stream
 
-import (
-	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
-)
-
 // Consumer interface to be implemented by different stream clients.
 type Consumer interface {
 	// Messages is a read-only channel on which the consumer delivers any messages
 	// being read from the stream.
 	//
-	// The channel returns each message as a `streammsg.Message` value object.
-	Messages() <-chan streammsg.Message
+	// The channel returns each message as a `stream.Message` value object.
+	Messages() <-chan Message
 
 	// Errors is a read-only channel on which the consumer delivers any errors
 	// that occurred while consuming from the stream.
@@ -19,11 +14,11 @@ type Consumer interface {
 
 	// Ack can be used to acknowledge that a message was processed and should not
 	// be delivered again.
-	Ack(streammsg.Message) error
+	Ack(Message) error
 
 	// Nack is the opposite of `Ack`. It can be used to indicate that a message
 	// was _not_ processed, and should be delivered again in the future.
-	Nack(streammsg.Message) error
+	Nack(Message) error
 
 	// Close closes the consumer. After calling this method, the consumer is no
 	// longer in a usable state, and subsequent method calls can result in
@@ -34,6 +29,8 @@ type Consumer interface {
 	// is terminated and the messages channel is closed.
 	Close() error
 
-	// Config returns the final configuration used by the consumer.
-	Config() streamconfig.Consumer
+	// Config returns the final configuration used by the consumer as an
+	// interface. To access the configuration, cast the interface to a
+	// `streamconfig.Consumer` struct.
+	Config() interface{}
 }

--- a/stream/consumermock.go
+++ b/stream/consumermock.go
@@ -1,21 +1,16 @@
 package stream
 
-import (
-	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
-)
-
 // ConsumerMock is a mock implementation of the Consumer interface
 type ConsumerMock struct {
-	Configuration streamconfig.Consumer
-	MessagesChan  chan streammsg.Message
+	Configuration interface{}
+	MessagesChan  chan Message
 	ErrorsChan    chan error
 }
 
 var _ Consumer = (*ConsumerMock)(nil)
 
 // Messages implements the Consumer interface for ConsumerMock.
-func (c *ConsumerMock) Messages() <-chan streammsg.Message {
+func (c *ConsumerMock) Messages() <-chan Message {
 	return c.MessagesChan
 }
 
@@ -25,12 +20,12 @@ func (c *ConsumerMock) Errors() <-chan error {
 }
 
 // Ack implements the Consumer interface for ConsumerMock.
-func (c *ConsumerMock) Ack(_ streammsg.Message) error {
+func (c *ConsumerMock) Ack(_ Message) error {
 	return nil
 }
 
 // Nack implements the Consumer interface for ConsumerMock.
-func (c *ConsumerMock) Nack(_ streammsg.Message) error {
+func (c *ConsumerMock) Nack(_ Message) error {
 	return nil
 }
 
@@ -42,6 +37,6 @@ func (c *ConsumerMock) Close() error {
 }
 
 // Config implements the Consumer interface for ConsumerMock.
-func (c ConsumerMock) Config() streamconfig.Consumer {
+func (c ConsumerMock) Config() interface{} {
 	return c.Configuration
 }

--- a/stream/message.go
+++ b/stream/message.go
@@ -1,4 +1,4 @@
-package streammsg
+package stream
 
 import (
 	"errors"

--- a/stream/message_test.go
+++ b/stream/message_test.go
@@ -1,4 +1,4 @@
-package streammsg
+package stream
 
 import (
 	"testing"

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -1,17 +1,12 @@
 package stream
 
-import (
-	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
-)
-
 // Producer interface to be implemented by different stream clients.
 type Producer interface {
 	// Messages is a write-only channel on which you can deliver any messages that
 	// need to be produced on the message stream.
 	//
-	// The channel accepts `streammsg.Message` value objects.
-	Messages() chan<- streammsg.Message
+	// The channel accepts `stream.Message` value objects.
+	Messages() chan<- Message
 
 	// Errors is a read-only channel on which the producer delivers any errors
 	// that occurred while producing to the stream.
@@ -26,6 +21,8 @@ type Producer interface {
 	// message stream and the messages channel is closed.
 	Close() error
 
-	// Config returns the final configuration used by the producer.
-	Config() streamconfig.Producer
+	// Config returns the final configuration used by the producer as an
+	// interface. To access the configuration, cast the interface to a
+	// `streamconfig.Producer` struct.
+	Config() interface{}
 }

--- a/stream/producermock.go
+++ b/stream/producermock.go
@@ -1,21 +1,16 @@
 package stream
 
-import (
-	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
-)
-
 // ProducerMock is a mock implementation of the Producer interface
 type ProducerMock struct {
-	Configuration streamconfig.Producer
-	MessagesChan  chan streammsg.Message
+	Configuration interface{}
+	MessagesChan  chan Message
 	ErrorsChan    chan error
 }
 
 var _ Producer = (*ProducerMock)(nil)
 
 // Messages implements the Producer interface for ProducerMock.
-func (p *ProducerMock) Messages() chan<- streammsg.Message {
+func (p *ProducerMock) Messages() chan<- Message {
 	return p.MessagesChan
 }
 
@@ -32,6 +27,6 @@ func (p *ProducerMock) Close() error {
 }
 
 // Config implements the Producer interface for ProducerMock.
-func (p ProducerMock) Config() streamconfig.Producer {
+func (p ProducerMock) Config() interface{} {
 	return p.Configuration
 }

--- a/stream/testing.go
+++ b/stream/testing.go
@@ -1,4 +1,4 @@
-package streammsg
+package stream
 
 import (
 	"testing"

--- a/stream/testing_test.go
+++ b/stream/testing_test.go
@@ -1,17 +1,17 @@
-package streammsg_test
+package stream_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTestMessage(t *testing.T) {
 	t.Parallel()
 
-	message := streammsg.TestMessage(t, "hello", "world")
+	message := stream.TestMessage(t, "hello", "world")
 
 	assert.Equal(t, "hello", string(message.Key))
 	assert.Equal(t, "world", string(message.Value))
@@ -25,7 +25,7 @@ func TestTestMessage(t *testing.T) {
 func TestTestMessage_DefaultKeyAndValue(t *testing.T) {
 	t.Parallel()
 
-	message := streammsg.TestMessage(t, "", "")
+	message := stream.TestMessage(t, "", "")
 
 	assert.Equal(t, "testKey", string(message.Key))
 	assert.Equal(t, "testValue", string(message.Value))

--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamcore"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"go.uber.org/zap"
 )
 
@@ -18,7 +17,7 @@ type Consumer struct {
 	c streamconfig.Consumer
 
 	logger   *zap.Logger
-	messages chan streammsg.Message
+	messages chan stream.Message
 	signals  chan os.Signal
 	errors   chan error
 	quit     chan bool
@@ -73,7 +72,7 @@ func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, erro
 
 // Messages returns the read channel for the messages that are returned by the
 // stream.
-func (c *Consumer) Messages() <-chan streammsg.Message {
+func (c *Consumer) Messages() <-chan stream.Message {
 	return c.messages
 }
 
@@ -84,12 +83,12 @@ func (c *Consumer) Errors() <-chan error {
 }
 
 // Ack is a no-op implementation to satisfy the stream.Consumer interface.
-func (c *Consumer) Ack(_ streammsg.Message) error {
+func (c *Consumer) Ack(_ stream.Message) error {
 	return nil
 }
 
 // Nack is a no-op implementation to satisfy the stream.Consumer interface.
-func (c *Consumer) Nack(_ streammsg.Message) error {
+func (c *Consumer) Nack(_ stream.Message) error {
 	return nil
 }
 
@@ -122,8 +121,10 @@ func (c *Consumer) Close() error {
 	return nil
 }
 
-// Config returns a read-only representation of the consumer configuration.
-func (c *Consumer) Config() streamconfig.Consumer {
+// Config returns a read-only representation of the consumer configuration as an
+// interface. To access the underlying configuration struct, cast the interface
+// to `streamconfig.Consumer`.
+func (c *Consumer) Config() interface{} {
 	return c.c
 }
 
@@ -179,7 +180,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 	consumer := &Consumer{
 		c:        config,
 		logger:   &config.Logger,
-		messages: make(chan streammsg.Message),
+		messages: make(chan stream.Message),
 		errors:   make(chan error),
 		quit:     make(chan bool),
 		once:     &sync.Once{},

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/stretchr/testify/assert"
@@ -45,15 +45,15 @@ func TestNewConsumer_WithOptions(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, consumer.Close()) }()
 
-	assert.Equal(t, store, consumer.Config().Inmem.Store)
+	assert.Equal(t, store, consumer.Config().(streamconfig.Consumer).Inmem.Store)
 }
 
 func TestConsumer_Messages(t *testing.T) {
 	t.Parallel()
 
 	store := inmemstore.New()
-	store.Add(streammsg.TestMessage(t, "key1", "hello world"))
-	store.Add(streammsg.TestMessage(t, "key2", "hello universe!"))
+	store.Add(stream.TestMessage(t, "key1", "hello world"))
+	store.Add(stream.TestMessage(t, "key2", "hello universe!"))
 
 	consumer, closer := inmemclient.TestConsumer(t, store)
 	defer closer()
@@ -75,7 +75,7 @@ func TestConsumer_Messages_Ordering(t *testing.T) {
 	store := inmemstore.New()
 
 	for i := 0; i < messageCount; i++ {
-		store.Add(streammsg.TestMessage(t, strconv.Itoa(i), "hello world"+strconv.Itoa(i)))
+		store.Add(stream.TestMessage(t, strconv.Itoa(i), "hello world"+strconv.Itoa(i)))
 	}
 
 	consumer, closer := inmemclient.TestConsumer(t, store)
@@ -100,7 +100,7 @@ func TestConsumer_Messages_PerMessageMemoryAllocation(t *testing.T) {
 	line := `{"number":%d}` + "\n"
 
 	for i := 0; i < messageCount; i++ {
-		store.Add(streammsg.TestMessage(t, strconv.Itoa(i), fmt.Sprintf(line, i)))
+		store.Add(stream.TestMessage(t, strconv.Itoa(i), fmt.Sprintf(line, i)))
 	}
 
 	consumer, closer := inmemclient.TestConsumer(t, store)
@@ -160,7 +160,7 @@ func TestConsumer_Ack(t *testing.T) {
 	consumer, closer := inmemclient.TestConsumer(t, nil)
 	defer closer()
 
-	assert.Nil(t, consumer.Ack(streammsg.Message{}))
+	assert.Nil(t, consumer.Ack(stream.Message{}))
 }
 
 func TestConsumer_Nack(t *testing.T) {
@@ -169,7 +169,7 @@ func TestConsumer_Nack(t *testing.T) {
 	consumer, closer := inmemclient.TestConsumer(t, nil)
 	defer closer()
 
-	assert.Nil(t, consumer.Nack(streammsg.Message{}))
+	assert.Nil(t, consumer.Nack(stream.Message{}))
 }
 
 func TestConsumer_Close(t *testing.T) {
@@ -203,7 +203,7 @@ func BenchmarkConsumer_Messages(b *testing.B) {
 	line := `{"number":%d}` + "\n"
 
 	for i := 1; i <= b.N; i++ {
-		store.Add(streammsg.TestMessage(b, strconv.Itoa(i), fmt.Sprintf(line, i)))
+		store.Add(stream.TestMessage(b, strconv.Itoa(i), fmt.Sprintf(line, i)))
 	}
 
 	b.ResetTimer()

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamcore"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"go.uber.org/zap"
 )
 
@@ -20,7 +19,7 @@ type Producer struct {
 	logger   *zap.Logger
 	wg       sync.WaitGroup
 	errors   chan error
-	messages chan<- streammsg.Message
+	messages chan<- stream.Message
 	signals  chan os.Signal
 	once     *sync.Once
 }
@@ -29,7 +28,7 @@ var _ stream.Producer = (*Producer)(nil)
 
 // NewProducer returns a new inmem producer.
 func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
-	ch := make(chan streammsg.Message)
+	ch := make(chan stream.Message)
 
 	producer, err := newProducer(ch, options)
 	if err != nil {
@@ -72,7 +71,7 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 }
 
 // Messages returns the write channel for messages to be produced.
-func (p *Producer) Messages() chan<- streammsg.Message {
+func (p *Producer) Messages() chan<- stream.Message {
 	return p.messages
 }
 
@@ -108,12 +107,14 @@ func (p *Producer) Close() error {
 	return nil
 }
 
-// Config returns a read-only representation of the producer configuration.
-func (p *Producer) Config() streamconfig.Producer {
+// Config returns a read-only representation of the producer configuration as an
+// interface. To access the underlying configuration struct, cast the interface
+// to `streamconfig.Producer`.
+func (p *Producer) Config() interface{} {
 	return p.c
 }
 
-func (p *Producer) produce(ch <-chan streammsg.Message) {
+func (p *Producer) produce(ch <-chan stream.Message) {
 	defer p.wg.Done()
 
 	for msg := range ch {
@@ -121,7 +122,7 @@ func (p *Producer) produce(ch <-chan streammsg.Message) {
 	}
 }
 
-func newProducer(ch chan streammsg.Message, options []func(*streamconfig.Producer)) (*Producer, error) {
+func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*Producer, error) {
 	config, err := streamconfig.NewProducer(options...)
 	if err != nil {
 		return nil, err

--- a/streamclient/inmemclient/testing_test.go
+++ b/streamclient/inmemclient/testing_test.go
@@ -26,7 +26,7 @@ func TestTestConsumer_WithStore(t *testing.T) {
 	consumer, closer := inmemclient.TestConsumer(t, store)
 	defer closer()
 
-	assert.EqualValues(t, store, consumer.Config().Inmem.Store)
+	assert.EqualValues(t, store, consumer.Config().(streamconfig.Consumer).Inmem.Store)
 }
 
 func TestTestConsumer_WithOptions(t *testing.T) {
@@ -43,7 +43,7 @@ func TestTestConsumer_WithOptions(t *testing.T) {
 	consumer, closer := inmemclient.TestConsumer(t, nil, options)
 	defer closer()
 
-	assert.EqualValues(t, store, consumer.Config().Inmem.Store)
+	assert.EqualValues(t, store, consumer.Config().(streamconfig.Consumer).Inmem.Store)
 }
 
 func TestTestProducer(t *testing.T) {
@@ -62,7 +62,7 @@ func TestTestProducer_WithStore(t *testing.T) {
 	producer, closer := inmemclient.TestProducer(t, store)
 	defer closer()
 
-	assert.EqualValues(t, store, producer.Config().Inmem.Store)
+	assert.EqualValues(t, store, producer.Config().(streamconfig.Producer).Inmem.Store)
 }
 
 func TestTestProducer_WithOptions(t *testing.T) {
@@ -79,5 +79,5 @@ func TestTestProducer_WithOptions(t *testing.T) {
 	producer, closer := inmemclient.TestProducer(t, nil, options)
 	defer closer()
 
-	assert.EqualValues(t, store, producer.Config().Inmem.Store)
+	assert.EqualValues(t, store, producer.Config().(streamconfig.Producer).Inmem.Store)
 }

--- a/streamclient/kafkaclient/eventhandlers.go
+++ b/streamclient/kafkaclient/eventhandlers.go
@@ -109,9 +109,9 @@ func (p *Producer) handleError(e kafka.Error) {
 }
 
 // handleMessage handles all Kafka messages by converting the message to a
-// `streammsg.Message` format, and delivers it to the receiver using the
-// messages channel. The return value indicates whether or not the quit signal
-// was received while waiting to deliver the message. This value is used by the
+// `stream.Message` format, and delivers it to the receiver using the messages
+// channel. The return value indicates whether or not the quit signal was
+// received while waiting to deliver the message. This value is used by the
 // consumer to close up shop.
 func (c *Consumer) handleMessage(e *kafka.Message) bool {
 	msg := newMessageFromKafka(e)

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +26,7 @@ func TestIntegrationTestConsumer(t *testing.T) {
 	defer closer()
 
 	assert.Equal(t, "*kafkaclient.Consumer", reflect.TypeOf(consumer).String())
-	assert.Equal(t, topicAndGroup, consumer.Config().Kafka.Topics[0])
+	assert.Equal(t, topicAndGroup, consumer.Config().(streamconfig.Consumer).Kafka.Topics[0])
 }
 
 func TestIntegrationTestConsumer_WithOptions(t *testing.T) {
@@ -41,8 +41,9 @@ func TestIntegrationTestConsumer_WithOptions(t *testing.T) {
 	consumer, closer := kafkaclient.TestConsumer(t, topicAndGroup, options)
 	defer closer()
 
-	assert.Equal(t, "TestTestConsumer_WithOptions", consumer.Config().Kafka.ID)
-	assert.Equal(t, topicAndGroup, consumer.Config().Kafka.Topics[0])
+	cfg := consumer.Config().(streamconfig.Consumer)
+	assert.Equal(t, "TestTestConsumer_WithOptions", cfg.Kafka.ID)
+	assert.Equal(t, topicAndGroup, cfg.Kafka.Topics[0])
 }
 
 func TestIntegrationTestProducer(t *testing.T) {
@@ -69,8 +70,9 @@ func TestIntegrationTestProducer_WithOptions(t *testing.T) {
 	producer, closer := kafkaclient.TestProducer(t, topic, options)
 	defer closer()
 
-	assert.Equal(t, "TestTestProducer_WithOptions", producer.Config().Kafka.ID)
-	assert.Equal(t, topic, producer.Config().Kafka.Topic)
+	cfg := producer.Config().(streamconfig.Producer)
+	assert.Equal(t, "TestTestProducer_WithOptions", cfg.Kafka.ID)
+	assert.Equal(t, topic, cfg.Kafka.Topic)
 }
 
 func TestIntegrationTestMessageFromTopic(t *testing.T) {
@@ -168,8 +170,8 @@ func TestIntegrationTestProduceMessages(t *testing.T) {
 			[]string{"hello world", "hello universe!"},
 		},
 
-		"streammsg.Message": {
-			[]interface{}{streammsg.Message{Value: []byte("hello world")}},
+		"stream.Message": {
+			[]interface{}{stream.Message{Value: []byte("hello world")}},
 			[]string{"hello world"},
 		},
 

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +44,7 @@ func TestNewConsumer_WithOptions(t *testing.T) {
 	consumer, err := standardstreamclient.NewConsumer(options)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, f, consumer.Config().Standardstream.Reader)
+	assert.EqualValues(t, f, consumer.Config().(streamconfig.Consumer).Standardstream.Reader)
 }
 
 func TestConsumer_Messages(t *testing.T) {
@@ -189,7 +189,7 @@ func TestConsumer_Ack(t *testing.T) {
 	consumer, closer := standardstreamclient.TestConsumer(t, b)
 	defer closer()
 
-	assert.Nil(t, consumer.Ack(streammsg.Message{}))
+	assert.Nil(t, consumer.Ack(stream.Message{}))
 }
 
 func TestConsumer_Nack(t *testing.T) {
@@ -199,7 +199,7 @@ func TestConsumer_Nack(t *testing.T) {
 	consumer, closer := standardstreamclient.TestConsumer(t, b)
 	defer closer()
 
-	assert.Nil(t, consumer.Nack(streammsg.Message{}))
+	assert.Nil(t, consumer.Nack(stream.Message{}))
 }
 
 func BenchmarkConsumer_Messages(b *testing.B) {

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +46,7 @@ func TestNewProducer_WithOptions(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, producer.Close()) }()
 
-	assert.EqualValues(t, buffer, producer.Config().Standardstream.Writer)
+	assert.EqualValues(t, buffer, producer.Config().(streamconfig.Producer).Standardstream.Writer)
 }
 
 func TestProducer_Messages(t *testing.T) {
@@ -56,7 +56,7 @@ func TestProducer_Messages(t *testing.T) {
 	buffer := standardstreamclient.TestBuffer(t)
 	producer, closer := standardstreamclient.TestProducer(t, buffer)
 
-	producer.Messages() <- streammsg.Message{Value: []byte(expected)}
+	producer.Messages() <- stream.Message{Value: []byte(expected)}
 	closer()
 
 	b, err := ioutil.ReadAll(buffer)
@@ -70,7 +70,7 @@ func TestProducer_Messages_AppendNewline(t *testing.T) {
 	buffer := standardstreamclient.TestBuffer(t)
 	producer, closer := standardstreamclient.TestProducer(t, buffer)
 
-	producer.Messages() <- streammsg.Message{Value: []byte("hello world")}
+	producer.Messages() <- stream.Message{Value: []byte("hello world")}
 	closer()
 
 	b, err := ioutil.ReadAll(buffer)
@@ -86,7 +86,7 @@ func TestProducer_Messages_Ordering(t *testing.T) {
 	producer, closer := standardstreamclient.TestProducer(t, buffer)
 
 	for i := 0; i < messageCount; i++ {
-		producer.Messages() <- streammsg.Message{Value: []byte(strconv.Itoa(i))}
+		producer.Messages() <- stream.Message{Value: []byte(strconv.Itoa(i))}
 	}
 	closer()
 
@@ -147,6 +147,6 @@ func BenchmarkProducer_Messages(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		producer.Messages() <- streammsg.Message{Value: []byte(fmt.Sprintf(`{"number":%d}`, i))}
+		producer.Messages() <- stream.Message{Value: []byte(fmt.Sprintf(`{"number":%d}`, i))}
 	}
 }

--- a/streamclient/standardstreamclient/testing_test.go
+++ b/streamclient/standardstreamclient/testing_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
+	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestTestConsumer(t *testing.T) {
 	defer closer()
 
 	assert.Equal(t, "*standardstreamclient.Consumer", reflect.TypeOf(consumer).String())
-	assert.EqualValues(t, buffer, consumer.Config().Standardstream.Reader)
+	assert.EqualValues(t, buffer, consumer.Config().(streamconfig.Consumer).Standardstream.Reader)
 }
 
 func TestTestProducer(t *testing.T) {
@@ -50,5 +51,5 @@ func TestTestProducer(t *testing.T) {
 	defer closer()
 
 	assert.Equal(t, "*standardstreamclient.Producer", reflect.TypeOf(producer).String())
-	assert.EqualValues(t, w, producer.Config().Standardstream.Writer)
+	assert.EqualValues(t, w, producer.Config().(streamconfig.Producer).Standardstream.Writer)
 }

--- a/streamclient/testing.go
+++ b/streamclient/testing.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/blendle/go-streamprocessor/stream"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +12,7 @@ import (
 // TestMessageFromConsumer returns a single message, consumed from the provided
 // consumer. It has a built-in timeout mechanism to prevent the test from
 // getting stuck.
-func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) streammsg.Message {
+func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) stream.Message {
 	tb.Helper()
 
 	select {
@@ -25,5 +24,5 @@ func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) streammsg.
 		require.Fail(tb, "Timeout while waiting for message to be returned.")
 	}
 
-	return streammsg.Message{}
+	return stream.Message{}
 }

--- a/streamclient/testing_test.go
+++ b/streamclient/testing_test.go
@@ -5,10 +5,10 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/inmemclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
-	"github.com/blendle/go-streamprocessor/streammsg"
 	"github.com/blendle/go-streamprocessor/streamutils/inmemstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +21,7 @@ func TestTestMessageFromConsumer(t *testing.T) {
 	producer, closer := inmemclient.TestProducer(t, store)
 	defer closer()
 
-	producer.Messages() <- streammsg.TestMessage(t, "hello", "world")
+	producer.Messages() <- stream.TestMessage(t, "hello", "world")
 
 	opts := func(c *streamconfig.Consumer) {
 		c.Inmem.ConsumeOnce = false

--- a/streamutils/inmemstore/store.go
+++ b/streamutils/inmemstore/store.go
@@ -4,30 +4,30 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/stream"
 )
 
 // Store hold the in-memory representation of a data storage service.
 type Store struct {
-	store []streammsg.Message
+	store []stream.Message
 	mutex sync.RWMutex
 }
 
 // New initializes a new store struct.
 func New() *Store {
-	return &Store{store: make([]streammsg.Message, 0)}
+	return &Store{store: make([]stream.Message, 0)}
 }
 
-// Add adds a streammsg.Message to the store.
-func (s *Store) Add(msg streammsg.Message) {
+// Add adds a stream.Message to the store.
+func (s *Store) Add(msg stream.Message) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
 	s.store = append(s.store, msg)
 }
 
-// Delete deletes a streammsg.Message from the store.
-func (s *Store) Delete(msg streammsg.Message) {
+// Delete deletes a stream.Message from the store.
+func (s *Store) Delete(msg stream.Message) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -42,7 +42,7 @@ func (s *Store) Delete(msg streammsg.Message) {
 }
 
 // Messages returns all messages in the store.
-func (s *Store) Messages() []streammsg.Message {
+func (s *Store) Messages() []stream.Message {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 

--- a/streamutils/inmemstore/store_test.go
+++ b/streamutils/inmemstore/store_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blendle/go-streamprocessor/streammsg"
+	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +22,7 @@ func TestAdd(t *testing.T) {
 	t.Parallel()
 
 	store := New()
-	m := streammsg.Message{
+	m := stream.Message{
 		Value:     []byte("testValue"),
 		Key:       []byte("testKey"),
 		Timestamp: time.Unix(0, 0),
@@ -54,7 +54,7 @@ func TestDelete(t *testing.T) {
 	t.Parallel()
 
 	store := New()
-	m1 := streammsg.Message{
+	m1 := stream.Message{
 		Value:     []byte("testValue1"),
 		Key:       []byte("testKey1"),
 		Timestamp: time.Unix(0, 0),
@@ -62,7 +62,7 @@ func TestDelete(t *testing.T) {
 		Tags:      map[string][]byte{"test": []byte("value"), "test2": []byte("value2")},
 	}
 
-	m2 := streammsg.Message{
+	m2 := stream.Message{
 		Value:     []byte("testValue2"),
 		Key:       []byte("testKey2"),
 		Timestamp: time.Unix(0, 0),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) {
 		Tags:      map[string][]byte{"test": []byte("value"), "test2": []byte("value2")},
 	}
 
-	m3 := streammsg.Message{
+	m3 := stream.Message{
 		Value:     []byte("testValue3"),
 		Key:       []byte("testKey3"),
 		Timestamp: time.Unix(0, 0),
@@ -97,7 +97,7 @@ func TestMessages(t *testing.T) {
 	t.Parallel()
 
 	store := New()
-	m := streammsg.Message{
+	m := stream.Message{
 		Value:     []byte("testValue"),
 		Key:       []byte("testKey"),
 		Timestamp: time.Unix(0, 0),


### PR DESCRIPTION
This makes it easier to use the Message struct, and it keeps the same
message package name as version 1 of the library.

To prevent a circular import cycle, the `Config()` function now returns
an interface that can be cast to either a `streamconfig.Consumer` or
`streamconfig.Producer` struct.

This is an acceptable trade-off, as you really only use this function
sparsely (and probably only in test scenarios), whereas you use the
`Message` struct constantly.