### PR TITLE
Change logger to be a pointer to zap.Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
 - chmod +x docker-compose
 - sudo mv docker-compose /usr/local/bin
 - script/cisetup
+- docker ps
 
 install: script/setup
 script: script/test
+after_failure: docker-compose logs

--- a/script/tests/gometalinter
+++ b/script/tests/gometalinter
@@ -18,12 +18,12 @@ if [ -n "$matches" ]; then
   exit 1
 fi
 
+# --warn-unmatched-nolint, disabled for now, see: https://git.io/vpGor
 gometalinter \
   --vendor \
   --tests \
   --aggregate \
   --sort=line \
-  --warn-unmatched-nolint \
   --deadline=300s \
   --vendored-linters \
   --enable-all \

--- a/script/tests/gometalinter
+++ b/script/tests/gometalinter
@@ -22,6 +22,8 @@ gometalinter \
   --vendor \
   --tests \
   --aggregate \
+  --sort=line \
+  --warn-unmatched-nolint \
   --deadline=300s \
   --vendored-linters \
   --enable-all \

--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -182,7 +182,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 
 	consumer := &Consumer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		messages: make(chan stream.Message),
 		errors:   make(chan error),
 		quit:     make(chan bool),

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -133,7 +133,7 @@ func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer))
 
 	producer := &Producer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		errors:   make(chan error),
 		messages: ch,
 		once:     &sync.Once{},

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -274,7 +274,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 
 	consumer := &Consumer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		kafka:    kafkaconsumer,
 		errors:   make(chan error),
 		messages: make(chan stream.Message),

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -210,7 +210,7 @@ func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer))
 
 	producer := &Producer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		kafka:    kafkaproducer,
 		errors:   make(chan error),
 		messages: ch,

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -160,7 +160,7 @@ func TestConsumerConfig(tb testing.TB, topicAndGroup string, options ...func(c *
 		require.NoError(tb, err)
 
 		verbose := func(c *streamconfig.Consumer) {
-			c.Logger = *logger.Named("TestConsumer")
+			c.Logger = logger.Named("TestConsumer")
 			c.Kafka.Debug.CGRP = true
 			c.Kafka.Debug.Topic = true
 		}
@@ -181,7 +181,7 @@ func TestProducerConfig(tb testing.TB, topic string, options ...func(c *streamco
 		require.NoError(tb, err)
 
 		verbose := func(c *streamconfig.Producer) {
-			c.Logger = *logger.Named("TestProducer")
+			c.Logger = logger.Named("TestProducer")
 			c.Kafka.Debug.CGRP = true
 			c.Kafka.Debug.Topic = true
 		}

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -230,6 +230,7 @@ func TestIntegrationTestOffsets(t *testing.T) {
 	config := &kafka.ConfigMap{
 		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
 		"produce.offset.report": false,
+		"message.timeout.ms":    60000,
 	}
 	producer, err := kafka.NewProducer(config)
 	require.NoError(t, err)

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -178,7 +178,7 @@ func newConsumer(options []func(*streamconfig.Consumer)) (*Consumer, error) {
 
 	consumer := &Consumer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		errors:   make(chan error),
 		messages: make(chan stream.Message),
 		once:     &sync.Once{},

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -145,7 +145,7 @@ func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer))
 
 	producer := &Producer{
 		c:        config,
-		logger:   &config.Logger,
+		logger:   config.Logger,
 		errors:   make(chan error),
 		messages: ch,
 		once:     &sync.Once{},

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -17,7 +17,7 @@ import (
 // these options can be passed into the new consumer to determine its behavior.
 // If the consumer only has to support a single implementation of the interface,
 // then all other configuration values can be ignored.
-type Consumer struct { // nolint:malign
+type Consumer struct {
 	Inmem          inmemconfig.Consumer
 	Kafka          kafkaconfig.Consumer
 	Pubsub         pubsubconfig.Consumer
@@ -60,7 +60,7 @@ type Consumer struct { // nolint:malign
 // these options can be passed into the new producer to determine its behavior.
 // If the producer only has to support a single implementation of the interface,
 // then all other configuration values can be ignored.
-type Producer struct { // nolint:malign
+type Producer struct {
 	Inmem          inmemconfig.Producer
 	Kafka          kafkaconfig.Producer
 	Pubsub         pubsubconfig.Producer

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -44,7 +44,7 @@ type Consumer struct { // nolint:malign
 
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
-	Logger zap.Logger `ignored:"true"`
+	Logger *zap.Logger `ignored:"true"`
 
 	// Name is the name of the current processor. It is currently only used to
 	// determine the prefix for environment-variable based configuration values.
@@ -87,7 +87,7 @@ type Producer struct { // nolint:malign
 
 	// Logger is the configurable logger instance to log messages. If left
 	// undefined, a no-op logger will be used.
-	Logger zap.Logger `ignored:"true"`
+	Logger *zap.Logger `ignored:"true"`
 
 	// Name is the name of the current processor. It is currently only used to
 	// determine the prefix for environment-variable based configuration values.
@@ -100,7 +100,7 @@ type Producer struct { // nolint:malign
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	Logger:          *zap.NewNop(),
+	Logger:          zap.NewNop(),
 	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "consumer",
@@ -109,7 +109,7 @@ var ConsumerDefaults = Consumer{
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
-	Logger:          *zap.NewNop(),
+	Logger:          zap.NewNop(),
 	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "producer",

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -24,7 +24,7 @@ func TestConsumer(t *testing.T) {
 		Kafka:           kafkaconfig.Consumer{},
 		Pubsub:          pubsubconfig.Consumer{},
 		Standardstream:  standardstreamconfig.Consumer{},
-		Logger:          *zap.NewNop(),
+		Logger:          zap.NewNop(),
 		HandleInterrupt: false,
 		Name:            "",
 		AllowEnvironmentBasedConfiguration: false,
@@ -36,7 +36,7 @@ func TestConsumerDefaults(t *testing.T) {
 
 	config := streamconfig.ConsumerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
 	assert.Equal(t, "consumer", config.Name)
 	assert.True(t, config.AllowEnvironmentBasedConfiguration)
@@ -286,7 +286,7 @@ func TestProducer(t *testing.T) {
 		Kafka:           kafkaconfig.Producer{},
 		Pubsub:          pubsubconfig.Producer{},
 		Standardstream:  standardstreamconfig.Producer{},
-		Logger:          *zap.NewNop(),
+		Logger:          zap.NewNop(),
 		HandleInterrupt: false,
 		Name:            "",
 		AllowEnvironmentBasedConfiguration: false,
@@ -298,7 +298,7 @@ func TestProducerDefaults(t *testing.T) {
 
 	config := streamconfig.ProducerDefaults
 
-	assert.Equal(t, "zap.Logger", reflect.TypeOf(config.Logger).String())
+	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
 	assert.True(t, config.HandleInterrupt)
 	assert.Equal(t, "producer", config.Name)
 	assert.True(t, config.AllowEnvironmentBasedConfiguration)

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -42,6 +42,11 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 		}
 	}
 
+	// Make sure we set a logger if it was explicitly set to nil.
+	if config.Logger == nil {
+		config.Logger = zap.NewNop()
+	}
+
 	config.Logger.Info(
 		"Finished preparing consumer configuration.",
 		zap.Any("config", config),
@@ -83,6 +88,11 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 		if err != nil {
 			return *config, err
 		}
+	}
+
+	// Make sure we set a logger if it was explicitly set to nil.
+	if config.Logger == nil {
+		config.Logger = zap.NewNop()
 	}
 
 	config.Logger.Info(

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -25,7 +25,7 @@ func TestNewConsumer(t *testing.T) {
 		{"kafkaconfig.Consumer", config.Kafka},
 		{"pubsubconfig.Consumer", config.Pubsub},
 		{"standardstreamconfig.Consumer", config.Standardstream},
-		{"zap.Logger", config.Logger},
+		{"*zap.Logger", config.Logger},
 	}
 
 	for _, tt := range tests {
@@ -49,6 +49,19 @@ func TestNewConsumer_WithOptions_Nil(t *testing.T) {
 
 	_, err := streamconfig.NewConsumer(nil)
 	assert.NoError(t, err)
+}
+
+func TestNewConsumer_WithOptions_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	options := func(c *streamconfig.Consumer) {
+		c.Logger = nil
+	}
+
+	config, err := streamconfig.NewConsumer(options)
+	require.NoError(t, err)
+
+	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
 }
 
 func TestNewConsumer_WithEnvironmentVariables(t *testing.T) {
@@ -107,7 +120,7 @@ func TestNewProducer(t *testing.T) {
 		{"kafkaconfig.Producer", config.Kafka},
 		{"pubsubconfig.Producer", config.Pubsub},
 		{"standardstreamconfig.Producer", config.Standardstream},
-		{"zap.Logger", config.Logger},
+		{"*zap.Logger", config.Logger},
 	}
 
 	for _, tt := range tests {
@@ -131,6 +144,19 @@ func TestNewProducer_WithOptions_Nil(t *testing.T) {
 
 	_, err := streamconfig.NewProducer(nil)
 	assert.NoError(t, err)
+}
+
+func TestNewProducer_WithOptions_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	options := func(c *streamconfig.Producer) {
+		c.Logger = nil
+	}
+
+	config, err := streamconfig.NewProducer(options)
+	require.NoError(t, err)
+
+	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
 }
 
 func TestNewProducer_WithEnvironmentVariables(t *testing.T) {

--- a/streamconfig/testing.go
+++ b/streamconfig/testing.go
@@ -9,7 +9,6 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // TestNewConsumer returns a new consumer configuration struct, optionally with
@@ -23,7 +22,7 @@ func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) C
 		c.Kafka = kafkaconfig.Consumer{}
 		c.Pubsub = pubsubconfig.Consumer{}
 		c.Standardstream = standardstreamconfig.Consumer{}
-		c.Logger = zap.Logger{}
+		c.Logger = nil
 		c.HandleInterrupt = false
 		c.HandleErrors = false
 		c.Name = ""
@@ -69,7 +68,7 @@ func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) P
 		p.Kafka = kafkaconfig.Producer{}
 		p.Pubsub = pubsubconfig.Producer{}
 		p.Standardstream = standardstreamconfig.Producer{}
-		p.Logger = zap.Logger{}
+		p.Logger = nil
 		p.HandleInterrupt = false
 		p.HandleErrors = false
 		p.Name = ""

--- a/streamconfig/testing_test.go
+++ b/streamconfig/testing_test.go
@@ -30,10 +30,10 @@ func TestTestNewConsumer_WithOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	options := func(c *streamconfig.Consumer) {
-		c.Logger = *logger
+		c.Logger = logger
 	}
 
-	c1 := streamconfig.Consumer{Logger: *logger}
+	c1 := streamconfig.Consumer{Logger: logger}
 	c2 := streamconfig.TestNewConsumer(t, false, options)
 
 	assert.EqualValues(t, c1, c2)
@@ -83,10 +83,10 @@ func TestTestNewProducer_WithOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	options := func(c *streamconfig.Producer) {
-		c.Logger = *logger
+		c.Logger = logger
 	}
 
-	p1 := streamconfig.Producer{Logger: *logger}
+	p1 := streamconfig.Producer{Logger: logger}
 	p2 := streamconfig.TestNewProducer(t, false, options)
 
 	assert.EqualValues(t, p1, p2)


### PR DESCRIPTION
This allows us to manipulate the functionality of the logger on runtime,
such as changing the log-level via a unix signal.