### PR TITLE
Don't export Consumer/Producer client structs

### DIFF
--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -31,19 +31,19 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 	}{
 		{
 			"standardstream",
-			"*standardstreamclient.Consumer",
+			"*standardstreamclient.consumer",
 			nil,
 		},
 
 		{
 			"inmem",
-			"*inmemclient.Consumer",
+			"*inmemclient.consumer",
 			nil,
 		},
 
 		{
 			"kafka",
-			"*kafkaclient.Consumer",
+			"*kafkaclient.consumer",
 			func(c *streamconfig.Consumer) {
 				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 				c.Kafka.Topics = []string{"test"}
@@ -78,7 +78,7 @@ func TestNewConsumer_PipedData(t *testing.T) {
 		consumer, err := streamclient.NewConsumer()
 		require.NoError(t, err)
 
-		require.Equal(t, "*standardstreamclient.Consumer", reflect.TypeOf(consumer).String())
+		require.Equal(t, "*standardstreamclient.consumer", reflect.TypeOf(consumer).String())
 		return
 	}
 

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -17,12 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConsumer(t *testing.T) {
-	t.Parallel()
-
-	_ = inmemclient.Consumer{}
-}
-
 func TestNewConsumer(t *testing.T) {
 	t.Parallel()
 
@@ -30,7 +24,7 @@ func TestNewConsumer(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, consumer.Close()) }()
 
-	assert.Equal(t, "*inmemclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*inmemclient.consumer", reflect.TypeOf(consumer).String())
 }
 
 func TestNewConsumer_WithOptions(t *testing.T) {

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -11,8 +11,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Producer implements the stream.Producer interface for the inmem client.
-type Producer struct {
+// producer implements the stream.Producer interface for the inmem client.
+type producer struct {
 	// c represents the configuration passed into the producer on
 	// initialization.
 	c streamconfig.Producer
@@ -25,20 +25,20 @@ type Producer struct {
 	once     *sync.Once
 }
 
-var _ stream.Producer = (*Producer)(nil)
+var _ stream.Producer = (*producer)(nil)
 
 // NewProducer returns a new inmem producer.
 func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
 	ch := make(chan stream.Message)
 
-	producer, err := newProducer(ch, options)
+	p, err := newProducer(ch, options)
 	if err != nil {
 		return nil, err
 	}
 
 	// add one to the WaitGroup. We remove this one only after all writes (below)
 	// are completed and the write channel is closed.
-	producer.wg.Add(1)
+	p.wg.Add(1)
 
 	// We start a goroutine to listen for errors on the errors channel, and log a
 	// fatal error (terminating the application in the process) when an error is
@@ -47,14 +47,14 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag. If the auto-error functionality is disabled, the user
 	// needs to manually listen to the `Errors()` channel and act accordingly.
-	if producer.c.HandleErrors {
-		go streamutil.HandleErrors(producer.errors, producer.logger.Fatal)
+	if p.c.HandleErrors {
+		go streamutil.HandleErrors(p.errors, p.logger.Fatal)
 	}
 
 	// We listen to the produce channel in a goroutine. Every message delivered to
 	// this producer gets stored in the inmem store. If the producer is closed,
 	// the close is blocked until the channel is closed.
-	go producer.produce(ch)
+	go p.produce(ch)
 
 	// Finally, we monitor for any interrupt signals. Ideally, the user handles
 	// these cases gracefully, but just in case, we try to close the producer if
@@ -63,28 +63,28 @@ func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, erro
 	//
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
-	if producer.c.HandleInterrupt {
-		producer.signals = make(chan os.Signal, 1)
-		go streamutil.HandleInterrupts(producer.signals, producer.Close, producer.logger)
+	if p.c.HandleInterrupt {
+		p.signals = make(chan os.Signal, 1)
+		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 
-	return producer, nil
+	return p, nil
 }
 
 // Messages returns the write channel for messages to be produced.
-func (p *Producer) Messages() chan<- stream.Message {
+func (p *producer) Messages() chan<- stream.Message {
 	return p.messages
 }
 
 // Errors returns the read channel for the errors that are returned by the
 // stream.
-func (p *Producer) Errors() <-chan error {
+func (p *producer) Errors() <-chan error {
 	return streamutil.ErrorsChan(p.errors, p.c.HandleErrors)
 }
 
 // Close closes the producer connection. This function blocks until all messages
 // still in the channel have been processed, and the channel is properly closed.
-func (p *Producer) Close() error {
+func (p *producer) Close() error {
 	p.once.Do(func() {
 		close(p.messages)
 
@@ -111,11 +111,11 @@ func (p *Producer) Close() error {
 // Config returns a read-only representation of the producer configuration as an
 // interface. To access the underlying configuration struct, cast the interface
 // to `streamconfig.Producer`.
-func (p *Producer) Config() interface{} {
+func (p *producer) Config() interface{} {
 	return p.c
 }
 
-func (p *Producer) produce(ch <-chan stream.Message) {
+func (p *producer) produce(ch <-chan stream.Message) {
 	defer p.wg.Done()
 
 	for msg := range ch {
@@ -125,13 +125,13 @@ func (p *Producer) produce(ch <-chan stream.Message) {
 	}
 }
 
-func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*Producer, error) {
+func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*producer, error) {
 	config, err := streamconfig.NewProducer(options...)
 	if err != nil {
 		return nil, err
 	}
 
-	producer := &Producer{
+	p := &producer{
 		c:        config,
 		logger:   config.Logger,
 		errors:   make(chan error),
@@ -139,5 +139,5 @@ func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer))
 		once:     &sync.Once{},
 	}
 
-	return producer, nil
+	return p, nil
 }

--- a/streamclient/inmemclient/producer_test.go
+++ b/streamclient/inmemclient/producer_test.go
@@ -16,12 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProducer(t *testing.T) {
-	t.Parallel()
-
-	_ = inmemclient.Producer{}
-}
-
 func TestNewProducer(t *testing.T) {
 	t.Parallel()
 
@@ -29,7 +23,7 @@ func TestNewProducer(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, producer.Close())
 
-	assert.Equal(t, "*inmemclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*inmemclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestNewProducer_WithOptions(t *testing.T) {

--- a/streamclient/inmemclient/testing_test.go
+++ b/streamclient/inmemclient/testing_test.go
@@ -16,7 +16,7 @@ func TestTestConsumer(t *testing.T) {
 	consumer, closer := inmemclient.TestConsumer(t, nil)
 	defer closer()
 
-	assert.Equal(t, "*inmemclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*inmemclient.consumer", reflect.TypeOf(consumer).String())
 }
 
 func TestTestConsumer_WithStore(t *testing.T) {
@@ -48,7 +48,7 @@ func TestTestProducer(t *testing.T) {
 	producer, closer := inmemclient.TestProducer(t, nil)
 	defer closer()
 
-	assert.Equal(t, "*inmemclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*inmemclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestTestProducer_WithStore(t *testing.T) {

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -18,12 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConsumer(t *testing.T) {
-	t.Parallel()
-
-	_ = kafkaclient.Consumer{}
-}
-
 func TestIntegrationNewConsumer(t *testing.T) {
 	t.Parallel()
 	testutil.Integration(t)
@@ -35,7 +29,7 @@ func TestIntegrationNewConsumer(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, consumer.Close()) }()
 
-	assert.Equal(t, "*kafkaclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*kafkaclient.consumer", reflect.TypeOf(consumer).String())
 }
 
 func TestIntegrationNewConsumer_WithOptions(t *testing.T) {

--- a/streamclient/kafkaclient/eventhandlers.go
+++ b/streamclient/kafkaclient/eventhandlers.go
@@ -7,7 +7,7 @@ import (
 )
 
 // handleAssignedPartitions assigns the consumer to a provided partition.
-func (c *Consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
+func (c *consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
 	c.logger.Info(
 		"Received event from Kafka.",
 		zap.String("eventType", "AssignedPartitions"),
@@ -29,7 +29,7 @@ func (c *Consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
 }
 
 // handleRevokedPartitions unassigns the consumer from a provided partition.
-func (c *Consumer) handleRevokedPartitions(e kafka.RevokedPartitions) {
+func (c *consumer) handleRevokedPartitions(e kafka.RevokedPartitions) {
 	log := c.logger.With(
 		zap.String("eventType", "RevokedPartitions"),
 		zap.String("eventDetails", e.String()),
@@ -63,7 +63,7 @@ func (c *Consumer) handleRevokedPartitions(e kafka.RevokedPartitions) {
 // returned message actually contains an error, we log that error, but don't
 // crash, as there's nothing we can do at this point, since the offset is
 // already delivered to Kafka.
-func (c *Consumer) handleOffsetCommitted(e kafka.OffsetsCommitted) {
+func (c *consumer) handleOffsetCommitted(e kafka.OffsetsCommitted) {
 	if e.Error == nil {
 		return
 	}
@@ -88,7 +88,7 @@ func (c *Consumer) handleOffsetCommitted(e kafka.OffsetsCommitted) {
 // We'll monitor this and see if we need to change this in the future. If you
 // want to handle this situation manually, use the `Events()` method to receive
 // the raised errors.
-func (c *Consumer) handleError(e kafka.Error) {
+func (c *consumer) handleError(e kafka.Error) {
 	c.errors <- errors.Wrap(e, "received error from event stream")
 }
 
@@ -104,7 +104,7 @@ func (c *Consumer) handleError(e kafka.Error) {
 // We'll monitor this and see if we need to change this in the future. If you
 // want to handle this situation manually, use the `Events()` method to receive
 // the raised errors.
-func (p *Producer) handleError(e kafka.Error) {
+func (p *producer) handleError(e kafka.Error) {
 	p.errors <- errors.Wrap(e, "received error from event stream")
 }
 
@@ -113,7 +113,7 @@ func (p *Producer) handleError(e kafka.Error) {
 // channel. The return value indicates whether or not the quit signal was
 // received while waiting to deliver the message. This value is used by the
 // consumer to close up shop.
-func (c *Consumer) handleMessage(e *kafka.Message) bool {
+func (c *consumer) handleMessage(e *kafka.Message) bool {
 	msg := newMessageFromKafka(e)
 
 	// Once the message has been prepared, we offer it to the consumer of
@@ -136,7 +136,7 @@ func (c *Consumer) handleMessage(e *kafka.Message) bool {
 // only relevant to validate that a published message was actually delivered as
 // expected. We check the error state of the message, and if there's an error,
 // we terminate the program, as there is no way to recover from this situation.
-func (p *Producer) handleMessage(e *kafka.Message) {
+func (p *producer) handleMessage(e *kafka.Message) {
 	if e.TopicPartition.Error == nil {
 		return
 	}

--- a/streamclient/kafkaclient/producer_test.go
+++ b/streamclient/kafkaclient/producer_test.go
@@ -17,12 +17,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestProducer(t *testing.T) {
-	t.Parallel()
-
-	_ = kafkaclient.Producer{}
-}
-
 func TestIntegrationNewProducer(t *testing.T) {
 	t.Parallel()
 	testutil.Integration(t)
@@ -34,7 +28,7 @@ func TestIntegrationNewProducer(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, producer.Close()) }()
 
-	assert.Equal(t, "*kafkaclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*kafkaclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestIntegrationNewProducer_WithOptions(t *testing.T) {

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -25,7 +25,7 @@ func TestIntegrationTestConsumer(t *testing.T) {
 	consumer, closer := kafkaclient.TestConsumer(t, topicAndGroup)
 	defer closer()
 
-	assert.Equal(t, "*kafkaclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*kafkaclient.consumer", reflect.TypeOf(consumer).String())
 	assert.Equal(t, topicAndGroup, consumer.Config().(streamconfig.Consumer).Kafka.Topics[0])
 }
 
@@ -55,7 +55,7 @@ func TestIntegrationTestProducer(t *testing.T) {
 	producer, closer := kafkaclient.TestProducer(t, topic)
 	defer closer()
 
-	assert.Equal(t, "*kafkaclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*kafkaclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestIntegrationTestProducer_WithOptions(t *testing.T) {

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -28,19 +28,19 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 	}{
 		{
 			"standardstream",
-			"*standardstreamclient.Producer",
+			"*standardstreamclient.producer",
 			nil,
 		},
 
 		{
 			"inmem",
-			"*inmemclient.Producer",
+			"*inmemclient.producer",
 			nil,
 		},
 
 		{
 			"kafka",
-			"*kafkaclient.Producer",
+			"*kafkaclient.producer",
 			func(c *streamconfig.Producer) {
 				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 				c.Kafka.Topic = "test"
@@ -76,7 +76,7 @@ func TestNewProducer_Env_DryRun(t *testing.T) {
 	producer, err := streamclient.NewProducer()
 	require.NoError(t, err)
 
-	assert.Equal(t, "*standardstreamclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*standardstreamclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestNewProducer_Env_DryRun_Overridden(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNewProducer_Env_DryRun_Overridden(t *testing.T) {
 	producer, err := streamclient.NewProducer()
 	require.NoError(t, err)
 
-	assert.Equal(t, "*inmemclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*inmemclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestNewProducer_Unknown(t *testing.T) {

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -17,19 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConsumer(t *testing.T) {
-	t.Parallel()
-
-	_ = standardstreamclient.Consumer{}
-}
-
 func TestNewConsumer(t *testing.T) {
 	t.Parallel()
 
 	consumer, err := standardstreamclient.NewConsumer()
 	require.NoError(t, err)
 
-	assert.Equal(t, "*standardstreamclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*standardstreamclient.consumer", reflect.TypeOf(consumer).String())
 }
 
 func TestNewConsumer_WithOptions(t *testing.T) {

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -17,12 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProducer(t *testing.T) {
-	t.Parallel()
-
-	_ = standardstreamclient.Producer{}
-}
-
 func TestNewProducer(t *testing.T) {
 	t.Parallel()
 
@@ -30,7 +24,7 @@ func TestNewProducer(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, producer.Close()) }()
 
-	assert.Equal(t, "*standardstreamclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*standardstreamclient.producer", reflect.TypeOf(producer).String())
 }
 
 func TestNewProducer_WithOptions(t *testing.T) {

--- a/streamclient/standardstreamclient/testing_test.go
+++ b/streamclient/standardstreamclient/testing_test.go
@@ -39,7 +39,7 @@ func TestTestConsumer(t *testing.T) {
 	consumer, closer := standardstreamclient.TestConsumer(t, buffer)
 	defer closer()
 
-	assert.Equal(t, "*standardstreamclient.Consumer", reflect.TypeOf(consumer).String())
+	assert.Equal(t, "*standardstreamclient.consumer", reflect.TypeOf(consumer).String())
 	assert.EqualValues(t, buffer, consumer.Config().(streamconfig.Consumer).Standardstream.Reader)
 }
 
@@ -50,6 +50,6 @@ func TestTestProducer(t *testing.T) {
 	producer, closer := standardstreamclient.TestProducer(t, w)
 	defer closer()
 
-	assert.Equal(t, "*standardstreamclient.Producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*standardstreamclient.producer", reflect.TypeOf(producer).String())
 	assert.EqualValues(t, w, producer.Config().(streamconfig.Producer).Standardstream.Writer)
 }


### PR DESCRIPTION
There's no need, so let's clean up our public API.