### PR TITLE
Implement new configuration API

### DIFF
--- a/streamclient/consumer.go
+++ b/streamclient/consumer.go
@@ -13,7 +13,7 @@ import (
 
 // NewConsumer returns a new streamclient consumer, based on the context from
 // which this function is called.
-func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	switch os.Getenv("STREAMCLIENT_CONSUMER") {
 	case "standardstream":
 		return standardstreamclient.NewConsumer(options...)

--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -27,7 +27,7 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 	var tests = []struct {
 		env    string
 		typeOf string
-		opts   func(*streamconfig.Consumer)
+		opts   streamconfig.Option
 	}{
 		{
 			"standardstream",
@@ -44,11 +44,11 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 		{
 			"kafka",
 			"*kafkaclient.consumer",
-			func(c *streamconfig.Consumer) {
+			streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
 				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
 				c.Kafka.Topics = []string{"test"}
 				c.Kafka.GroupID = "test"
-			},
+			}),
 		},
 	}
 

--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -29,7 +29,7 @@ type consumer struct {
 var _ stream.Consumer = (*consumer)(nil)
 
 // NewConsumer returns a new inmem consumer.
-func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	c, err := newConsumer(options)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (c *consumer) consume() {
 	}
 }
 
-func newConsumer(options []func(*streamconfig.Consumer)) (*consumer, error) {
+func newConsumer(options []streamconfig.Option) (*consumer, error) {
 	config, err := streamconfig.NewConsumer(options...)
 	if err != nil {
 		return nil, err

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -30,12 +30,7 @@ func TestNewConsumer(t *testing.T) {
 func TestNewConsumer_WithOptions(t *testing.T) {
 	t.Parallel()
 
-	store := inmemstore.New()
-	options := func(c *streamconfig.Consumer) {
-		c.Inmem.Store = store
-	}
-
-	consumer, err := inmemclient.NewConsumer(options)
+	consumer, err := inmemclient.NewConsumer(streamconfig.InmemStore(inmemstore.New()))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, consumer.Close()) }()
 }
@@ -117,9 +112,9 @@ func TestConsumer_Messages_PerMessageMemoryAllocation(t *testing.T) {
 func TestConsumer_Errors(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Consumer) {
+	options := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
 		c.HandleErrors = true
-	}
+	})
 
 	consumer, closer := inmemclient.TestConsumer(t, nil, options)
 	defer closer()
@@ -132,11 +127,7 @@ func TestConsumer_Errors(t *testing.T) {
 func TestConsumer_Errors_Manual(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Consumer) {
-		c.HandleErrors = false
-	}
-
-	consumer, closer := inmemclient.TestConsumer(t, nil, options)
+	consumer, closer := inmemclient.TestConsumer(t, nil, streamconfig.ManualErrorHandling())
 	defer closer()
 
 	select {
@@ -167,11 +158,7 @@ func TestConsumer_Nack(t *testing.T) {
 func TestConsumer_Close(t *testing.T) {
 	t.Parallel()
 
-	opts := func(c *streamconfig.Consumer) {
-		c.Inmem.ConsumeOnce = false
-	}
-
-	consumer, err := inmemclient.NewConsumer(opts)
+	consumer, err := inmemclient.NewConsumer(streamconfig.InmemListen())
 	require.NoError(t, err)
 
 	ch := make(chan error)

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -28,7 +28,7 @@ type producer struct {
 var _ stream.Producer = (*producer)(nil)
 
 // NewProducer returns a new inmem producer.
-func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	ch := make(chan stream.Message)
 
 	p, err := newProducer(ch, options)
@@ -125,7 +125,7 @@ func (p *producer) produce(ch <-chan stream.Message) {
 	}
 }
 
-func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*producer, error) {
+func newProducer(ch chan stream.Message, options []streamconfig.Option) (*producer, error) {
 	config, err := streamconfig.NewProducer(options...)
 	if err != nil {
 		return nil, err

--- a/streamclient/inmemclient/producer_test.go
+++ b/streamclient/inmemclient/producer_test.go
@@ -29,12 +29,7 @@ func TestNewProducer(t *testing.T) {
 func TestNewProducer_WithOptions(t *testing.T) {
 	t.Parallel()
 
-	store := inmemstore.New()
-	options := func(c *streamconfig.Producer) {
-		c.Inmem.Store = store
-	}
-
-	producer, err := inmemclient.NewProducer(options)
+	producer, err := inmemclient.NewProducer(streamconfig.InmemStore(inmemstore.New()))
 	require.NoError(t, err)
 	defer require.NoError(t, producer.Close())
 }
@@ -78,9 +73,9 @@ func TestProducer_MessageOrdering(t *testing.T) {
 func TestProducer_Errors(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Producer) {
+	options := streamconfig.ProducerOptions(func(c *streamconfig.Producer) {
 		c.HandleErrors = true
-	}
+	})
 
 	producer, closer := inmemclient.TestProducer(t, nil, options)
 	defer closer()
@@ -93,11 +88,7 @@ func TestProducer_Errors(t *testing.T) {
 func TestProducer_Errors_Manual(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Producer) {
-		c.HandleErrors = false
-	}
-
-	producer, closer := inmemclient.TestProducer(t, nil, options)
+	producer, closer := inmemclient.TestProducer(t, nil, streamconfig.ManualErrorHandling())
 	defer closer()
 
 	select {

--- a/streamclient/inmemclient/testing.go
+++ b/streamclient/inmemclient/testing.go
@@ -17,16 +17,14 @@ import (
 //
 // You can optionally provide extra options to be used when instantiating the
 // consumer.
-func TestConsumer(tb testing.TB, s stream.Store, options ...func(c *streamconfig.Consumer)) (stream.Consumer, func()) {
+func TestConsumer(tb testing.TB, s stream.Store, options ...streamconfig.Option) (stream.Consumer, func()) {
 	tb.Helper()
 
 	if s == nil {
 		s = inmemstore.New()
 	}
 
-	options = append(options, func(c *streamconfig.Consumer) {
-		c.Inmem.Store = s
-	})
+	options = append(options, streamconfig.InmemStore(s))
 
 	consumer, err := NewConsumer(options...)
 	require.NoError(tb, err)
@@ -39,16 +37,14 @@ func TestConsumer(tb testing.TB, s stream.Store, options ...func(c *streamconfig
 //
 // You can either pass a pre-configured inmemstore to this function as its
 // second argument, or pass in `nil`, to have one be instantiated for you.
-func TestProducer(tb testing.TB, s stream.Store, options ...func(c *streamconfig.Producer)) (stream.Producer, func()) {
+func TestProducer(tb testing.TB, s stream.Store, options ...streamconfig.Option) (stream.Producer, func()) {
 	tb.Helper()
 
 	if s == nil {
 		s = inmemstore.New()
 	}
 
-	options = append(options, func(c *streamconfig.Producer) {
-		c.Inmem.Store = s
-	})
+	options = append(options, streamconfig.InmemStore(s))
 
 	producer, err := NewProducer(options...)
 	require.NoError(tb, err)

--- a/streamclient/inmemclient/testing_test.go
+++ b/streamclient/inmemclient/testing_test.go
@@ -31,15 +31,14 @@ func TestTestConsumer_WithOptions(t *testing.T) {
 	t.Parallel()
 
 	store := inmemstore.New()
-	options := func(c *streamconfig.Consumer) {
-		c.Inmem.Store = store
-	}
 
 	// setting the second argument (the store) to nil will instantiate a new store
 	// in the initializer, but since we also pass in our own store as an optional
 	// argument, it will be the eventual store used by this consumer.
-	_, closer := inmemclient.TestConsumer(t, nil, options)
+	consumer, closer := inmemclient.TestConsumer(t, nil, streamconfig.InmemStore(store))
 	defer closer()
+
+	assert.EqualValues(t, store, consumer.Config().(streamconfig.Consumer).Inmem.Store)
 }
 
 func TestTestProducer(t *testing.T) {
@@ -65,14 +64,11 @@ func TestTestProducer_WithOptions(t *testing.T) {
 	t.Parallel()
 
 	store := inmemstore.New()
-	options := func(c *streamconfig.Producer) {
-		c.Inmem.Store = store
-	}
 
 	// setting the second argument (the store) to nil will instantiate a new store
 	// in the initializer, but since we also pass in our own store as an optional
 	// argument, it will be the eventual store used by this producer.
-	producer, closer := inmemclient.TestProducer(t, nil, options)
+	producer, closer := inmemclient.TestProducer(t, nil, streamconfig.InmemStore(store))
 	defer closer()
 
 	assert.EqualValues(t, store, producer.Config().(streamconfig.Producer).Inmem.Store)

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -35,7 +35,7 @@ type opaque struct {
 var _ stream.Consumer = (*consumer)(nil)
 
 // NewConsumer returns a new Kafka consumer.
-func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	c, err := newConsumer(options)
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (c *consumer) consume() {
 	}
 }
 
-func newConsumer(options []func(*streamconfig.Consumer)) (*consumer, error) {
+func newConsumer(options []streamconfig.Option) (*consumer, error) {
 	// Construct a full configuration object, based on the provided configuration,
 	// the default configurations, and the static configurations.
 	config, err := streamconfig.NewConsumer(options...)

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -32,7 +32,7 @@ type producer struct {
 var _ stream.Producer = (*producer)(nil)
 
 // NewProducer returns a new Kafka producer.
-func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	ch := make(chan stream.Message)
 
 	p, err := newProducer(ch, options)
@@ -182,7 +182,7 @@ func (p *producer) produce(ch <-chan stream.Message) {
 	}
 }
 
-func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*producer, error) {
+func newProducer(ch chan stream.Message, options []streamconfig.Option) (*producer, error) {
 	// Construct a full configuration object, based on the provided configuration,
 	// the default configurations, and the static configurations.
 	config, err := streamconfig.NewProducer(options...)

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -34,11 +34,9 @@ func TestIntegrationTestConsumer_WithOptions(t *testing.T) {
 	testutil.Integration(t)
 
 	topicAndGroup := testutil.Random(t)
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.ID = "TestTestConsumer_WithOptions"
-	}
 
-	consumer, closer := kafkaclient.TestConsumer(t, topicAndGroup, options)
+	id := streamconfig.KafkaID("TestTestConsumer_WithOptions")
+	consumer, closer := kafkaclient.TestConsumer(t, topicAndGroup, id)
 	defer closer()
 
 	cfg := consumer.Config().(streamconfig.Consumer)
@@ -63,11 +61,9 @@ func TestIntegrationTestProducer_WithOptions(t *testing.T) {
 	testutil.Integration(t)
 
 	topic := testutil.Random(t)
-	options := func(c *streamconfig.Producer) {
-		c.Kafka.ID = "TestTestProducer_WithOptions"
-	}
 
-	producer, closer := kafkaclient.TestProducer(t, topic, options)
+	id := streamconfig.KafkaID("TestTestProducer_WithOptions")
+	producer, closer := kafkaclient.TestProducer(t, topic, id)
 	defer closer()
 
 	cfg := producer.Config().(streamconfig.Producer)
@@ -97,13 +93,11 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	require.Zero(t, producer.Flush(1000))
 	producer.Close()
 
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
-		c.Kafka.Topics = []string{topicAndGroup}
-		c.Kafka.GroupID = topicAndGroup
-	}
-
-	consumer, err := kafkaclient.NewConsumer(options)
+	consumer, err := kafkaclient.NewConsumer(
+		streamconfig.KafkaBroker(kafkaconfig.TestBrokerAddress),
+		streamconfig.KafkaTopic(topicAndGroup),
+		streamconfig.KafkaGroupID(topicAndGroup),
+	)
 	require.NoError(t, err)
 	defer func() {
 		time.Sleep(100 * time.Millisecond)
@@ -241,13 +235,11 @@ func TestIntegrationTestOffsets(t *testing.T) {
 	<-producer.Events()
 	producer.Close()
 
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
-		c.Kafka.Topics = []string{topicAndGroup}
-		c.Kafka.GroupID = topicAndGroup
-	}
-
-	consumer, err := kafkaclient.NewConsumer(options)
+	consumer, err := kafkaclient.NewConsumer(
+		streamconfig.KafkaBroker(kafkaconfig.TestBrokerAddress),
+		streamconfig.KafkaTopic(topicAndGroup),
+		streamconfig.KafkaGroupID(topicAndGroup),
+	)
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, consumer.Close()) }()
 

--- a/streamclient/producer.go
+++ b/streamclient/producer.go
@@ -13,7 +13,7 @@ import (
 
 // NewProducer returns a new streamclient producer, based on the context from
 // which this function is called.
-func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	switch os.Getenv("STREAMCLIENT_PRODUCER") {
 	case "standardstream":
 		return standardstreamclient.NewProducer(options...)

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -24,7 +24,7 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 	var tests = []struct {
 		env    string
 		typeOf string
-		opts   func(*streamconfig.Producer)
+		opts   streamconfig.Option
 	}{
 		{
 			"standardstream",
@@ -41,10 +41,10 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 		{
 			"kafka",
 			"*kafkaclient.producer",
-			func(c *streamconfig.Producer) {
-				c.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
-				c.Kafka.Topic = "test"
-			},
+			streamconfig.ProducerOptions(func(p *streamconfig.Producer) {
+				p.Kafka.Brokers = []string{kafkaconfig.TestBrokerAddress}
+				p.Kafka.Topic = "test"
+			}),
 		},
 	}
 

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -36,7 +36,7 @@ type consumer struct {
 var _ stream.Consumer = (*consumer)(nil)
 
 // NewConsumer returns a new standard stream consumer.
-func NewConsumer(options ...func(*streamconfig.Consumer)) (stream.Consumer, error) {
+func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	c, err := newConsumer(options)
 	if err != nil {
 		return nil, err
@@ -170,7 +170,7 @@ func (c *consumer) consume() {
 	}
 }
 
-func newConsumer(options []func(*streamconfig.Consumer)) (*consumer, error) {
+func newConsumer(options []streamconfig.Option) (*consumer, error) {
 	config, err := streamconfig.NewConsumer(options...)
 	if err != nil {
 		return nil, err

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -31,11 +31,7 @@ func TestNewConsumer_WithOptions(t *testing.T) {
 
 	f := standardstreamclient.TestBuffer(t)
 
-	options := func(c *streamconfig.Consumer) {
-		c.Standardstream.Reader = f
-	}
-
-	consumer, err := standardstreamclient.NewConsumer(options)
+	consumer, err := standardstreamclient.NewConsumer(streamconfig.StandardstreamReader(f))
 	require.NoError(t, err)
 
 	assert.EqualValues(t, f, consumer.Config().(streamconfig.Consumer).Standardstream.Reader)
@@ -145,9 +141,9 @@ func TestConsumer_Messages_ScannerError(t *testing.T) {
 func TestConsumer_Errors(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Consumer) {
+	options := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
 		c.HandleErrors = true
-	}
+	})
 
 	b := standardstreamclient.TestBuffer(t)
 	consumer, closer := standardstreamclient.TestConsumer(t, b, options)
@@ -161,12 +157,8 @@ func TestConsumer_Errors(t *testing.T) {
 func TestConsumer_Errors_Manual(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Consumer) {
-		c.HandleErrors = false
-	}
-
 	b := standardstreamclient.TestBuffer(t)
-	consumer, closer := standardstreamclient.TestConsumer(t, b, options)
+	consumer, closer := standardstreamclient.TestConsumer(t, b, streamconfig.ManualErrorHandling())
 	defer closer()
 
 	select {

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -30,7 +30,7 @@ type producer struct {
 var _ stream.Producer = (*producer)(nil)
 
 // NewProducer returns a new standard stream producer.
-func NewProducer(options ...func(*streamconfig.Producer)) (stream.Producer, error) {
+func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	ch := make(chan stream.Message)
 
 	p, err := newProducer(ch, options)
@@ -137,7 +137,7 @@ func (p *producer) produce(ch <-chan stream.Message) {
 	}
 }
 
-func newProducer(ch chan stream.Message, options []func(*streamconfig.Producer)) (*producer, error) {
+func newProducer(ch chan stream.Message, options []streamconfig.Option) (*producer, error) {
 	config, err := streamconfig.NewProducer(options...)
 	if err != nil {
 		return nil, err

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -32,11 +32,7 @@ func TestNewProducer_WithOptions(t *testing.T) {
 
 	buffer := standardstreamclient.TestBuffer(t)
 
-	options := func(c *streamconfig.Producer) {
-		c.Standardstream.Writer = buffer
-	}
-
-	producer, err := standardstreamclient.NewProducer(options)
+	producer, err := standardstreamclient.NewProducer(streamconfig.StandardstreamWriter(buffer))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, producer.Close()) }()
 
@@ -102,9 +98,9 @@ func TestProducer_Messages_Ordering(t *testing.T) {
 func TestProducer_Errors(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Producer) {
+	options := streamconfig.ProducerOptions(func(c *streamconfig.Producer) {
 		c.HandleErrors = true
-	}
+	})
 
 	b := standardstreamclient.TestBuffer(t)
 	producer, closer := standardstreamclient.TestProducer(t, b, options)
@@ -118,12 +114,8 @@ func TestProducer_Errors(t *testing.T) {
 func TestProducer_Errors_Manual(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Producer) {
-		c.HandleErrors = false
-	}
-
 	b := standardstreamclient.TestBuffer(t)
-	producer, closer := standardstreamclient.TestProducer(t, b, options)
+	producer, closer := standardstreamclient.TestProducer(t, b, streamconfig.ManualErrorHandling())
 	defer closer()
 
 	select {

--- a/streamclient/standardstreamclient/testing.go
+++ b/streamclient/standardstreamclient/testing.go
@@ -31,12 +31,10 @@ func TestBuffer(tb testing.TB, v ...string) io.ReadWriteCloser {
 //
 // The return value is the consumer, and a function that should be deferred to
 // clean up resources.
-func TestConsumer(tb testing.TB, r io.ReadCloser, options ...func(c *streamconfig.Consumer)) (stream.Consumer, func()) {
+func TestConsumer(tb testing.TB, r io.ReadCloser, options ...streamconfig.Option) (stream.Consumer, func()) {
 	tb.Helper()
 
-	options = append(options, func(c *streamconfig.Consumer) {
-		c.Standardstream.Reader = r
-	})
+	options = append(options, streamconfig.StandardstreamReader(r))
 
 	consumer, err := NewConsumer(streamconfig.TestConsumerOptions(tb, options...)...)
 	require.NoError(tb, err)
@@ -49,12 +47,10 @@ func TestConsumer(tb testing.TB, r io.ReadCloser, options ...func(c *streamconfi
 //
 // The return value is the producer, and a function that should be deferred to
 // clean up resources.
-func TestProducer(tb testing.TB, w io.Writer, options ...func(c *streamconfig.Producer)) (stream.Producer, func()) {
+func TestProducer(tb testing.TB, w io.Writer, options ...streamconfig.Option) (stream.Producer, func()) {
 	tb.Helper()
 
-	options = append(options, func(c *streamconfig.Producer) {
-		c.Standardstream.Writer = w
-	})
+	options = append(options, streamconfig.StandardstreamWriter(w))
 
 	producer, err := NewProducer(options...)
 	require.NoError(tb, err)

--- a/streamclient/testing_test.go
+++ b/streamclient/testing_test.go
@@ -23,11 +23,7 @@ func TestTestMessageFromConsumer(t *testing.T) {
 
 	producer.Messages() <- stream.TestMessage(t, "hello", "world")
 
-	opts := func(c *streamconfig.Consumer) {
-		c.Inmem.ConsumeOnce = false
-	}
-
-	consumer, closer := inmemclient.TestConsumer(t, store, opts)
+	consumer, closer := inmemclient.TestConsumer(t, store, streamconfig.InmemListen())
 	defer closer()
 
 	message := streamclient.TestMessageFromConsumer(t, consumer)
@@ -40,11 +36,7 @@ func TestTestMessageFromConsumer_Timeout(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv("BE_TESTING_FATAL") == "1" {
-		opts := func(c *streamconfig.Consumer) {
-			c.Inmem.ConsumeOnce = false
-		}
-
-		consumer, closer := inmemclient.TestConsumer(t, nil, opts)
+		consumer, closer := inmemclient.TestConsumer(t, nil, streamconfig.InmemListen())
 		defer closer()
 
 		_ = streamclient.TestMessageFromConsumer(t, consumer)

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -116,12 +116,37 @@ var ProducerDefaults = Producer{
 	AllowEnvironmentBasedConfiguration: true,
 }
 
-// Usage calls the usage() function and returns a byte array.
+// WithOptions takes the current Consumer, applies the supplied Options, and
+// returns the resulting Consumer.
+func (c Consumer) WithOptions(opts ...Option) Consumer {
+	cc := &c
+
+	for _, opt := range opts {
+		opt.apply(cc, nil)
+	}
+
+	return *cc
+}
+
+// TODO: implement `--help` by default, and add `EnableHelpFlag`.
+
 // Usage returns a byte array with a table-based explanation on how to set the
 // configuration values using environment variables. This can be used to explain
 // usage details to the user of the application.
 func (c Consumer) Usage() []byte {
 	return usage(c.Name, c)
+}
+
+// WithOptions takes the current Producer, applies the supplied Options, and
+// returns the resulting Producer.
+func (p Producer) WithOptions(opts ...Option) Producer {
+	pp := &p
+
+	for _, opt := range opts {
+		opt.apply(nil, pp)
+	}
+
+	return *pp
 }
 
 // Usage returns a byte array with a table-based explanation on how to set the

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -268,10 +268,10 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 
 			tt.config.Name = "consumer"
 			tt.config.AllowEnvironmentBasedConfiguration = true
-			options := func(c *streamconfig.Consumer) {
+			options := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
 				c.Name = "consumer"
 				c.AllowEnvironmentBasedConfiguration = true
-			}
+			})
 
 			assert.EqualValues(t, tt.config, streamconfig.TestNewConsumer(t, false, options))
 		})
@@ -588,10 +588,10 @@ func TestProducerEnvironmentVariables(t *testing.T) {
 
 			tt.config.Name = "producer"
 			tt.config.AllowEnvironmentBasedConfiguration = true
-			options := func(c *streamconfig.Producer) {
+			options := streamconfig.ProducerOptions(func(c *streamconfig.Producer) {
 				c.Name = "producer"
 				c.AllowEnvironmentBasedConfiguration = true
-			}
+			})
 
 			assert.EqualValues(t, tt.config, streamconfig.TestNewProducer(t, false, options))
 		})

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -25,6 +25,10 @@ func NewConsumer(options ...Option) (Consumer, error) {
 	// value with any custom configuration values passed into the `NewConsumer`
 	// function.
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
 		option.apply(config, nil)
 	}
 
@@ -69,6 +73,10 @@ func NewProducer(options ...Option) (Producer, error) {
 	// value with any custom configuration values passed into the `NewProducer`
 	// function.
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
+
 		option.apply(nil, config)
 	}
 

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -12,7 +12,7 @@ import (
 // NewConsumer returns a new Consumer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
+func NewConsumer(options ...Option) (Consumer, error) {
 	defaults := ConsumerDefaults
 
 	config := &defaults
@@ -25,11 +25,7 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 	// value with any custom configuration values passed into the `NewConsumer`
 	// function.
 	for _, option := range options {
-		if option == nil {
-			continue
-		}
-
-		option(config)
+		option.apply(config, nil)
 	}
 
 	// Finally, we set/overwrite any value with any custom configuration values
@@ -60,7 +56,7 @@ func NewConsumer(options ...func(*Consumer)) (Consumer, error) {
 // NewProducer returns a new Producer configuration struct, containing the
 // values passed into the function. If any error occurs during configuration
 // validation, an error is returned as the second argument.
-func NewProducer(options ...func(*Producer)) (Producer, error) {
+func NewProducer(options ...Option) (Producer, error) {
 	defaults := ProducerDefaults
 
 	config := &defaults
@@ -73,11 +69,7 @@ func NewProducer(options ...func(*Producer)) (Producer, error) {
 	// value with any custom configuration values passed into the `NewProducer`
 	// function.
 	for _, option := range options {
-		if option == nil {
-			continue
-		}
-
-		option(config)
+		option.apply(nil, config)
 	}
 
 	// Finally, we set/overwrite any value with any custom configuration values

--- a/streamconfig/initializers_test.go
+++ b/streamconfig/initializers_test.go
@@ -34,11 +34,7 @@ func TestNewConsumer(t *testing.T) {
 }
 
 func TestNewConsumer_WithOptions(t *testing.T) {
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.ID = "test"
-	}
-
-	config, err := streamconfig.NewConsumer(options)
+	config, err := streamconfig.NewConsumer(streamconfig.KafkaID("test"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", config.Kafka.ID)
@@ -54,11 +50,7 @@ func TestNewConsumer_WithOptions_Nil(t *testing.T) {
 func TestNewConsumer_WithOptions_NilLogger(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Consumer) {
-		c.Logger = nil
-	}
-
-	config, err := streamconfig.NewConsumer(options)
+	config, err := streamconfig.NewConsumer(streamconfig.Logger(nil))
 	require.NoError(t, err)
 
 	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
@@ -78,12 +70,10 @@ func TestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{"broker2"}
-		c.Kafka.ID = "test"
-	}
-
-	config, err := streamconfig.NewConsumer(options)
+	config, err := streamconfig.NewConsumer(
+		streamconfig.KafkaBroker("broker2"),
+		streamconfig.KafkaID("test"),
+	)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
@@ -94,12 +84,10 @@ func TestNewConsumer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Consumer) {
-		c.AllowEnvironmentBasedConfiguration = false
-		c.Kafka.Brokers = []string{"broker2"}
-	}
-
-	config, err := streamconfig.NewConsumer(options)
+	config, err := streamconfig.NewConsumer(
+		streamconfig.DisableEnvironmentConfig(),
+		streamconfig.KafkaBroker("broker2"),
+	)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)
@@ -129,11 +117,7 @@ func TestNewProducer(t *testing.T) {
 }
 
 func TestNewProducer_WithOptions(t *testing.T) {
-	options := func(c *streamconfig.Producer) {
-		c.Kafka.ID = "test"
-	}
-
-	config, err := streamconfig.NewProducer(options)
+	config, err := streamconfig.NewProducer(streamconfig.KafkaID("test"))
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", config.Kafka.ID)
@@ -149,11 +133,7 @@ func TestNewProducer_WithOptions_Nil(t *testing.T) {
 func TestNewProducer_WithOptions_NilLogger(t *testing.T) {
 	t.Parallel()
 
-	options := func(c *streamconfig.Producer) {
-		c.Logger = nil
-	}
-
-	config, err := streamconfig.NewProducer(options)
+	config, err := streamconfig.NewProducer(streamconfig.Logger(nil))
 	require.NoError(t, err)
 
 	assert.Equal(t, "*zap.Logger", reflect.TypeOf(config.Logger).String())
@@ -173,12 +153,10 @@ func TestNewProducer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("PRODUCER_KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("PRODUCER_KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Producer) {
-		c.Kafka.Brokers = []string{"broker2"}
-		c.Kafka.ID = "test"
-	}
-
-	config, err := streamconfig.NewProducer(options)
+	config, err := streamconfig.NewProducer(
+		streamconfig.KafkaBroker("broker2"),
+		streamconfig.KafkaID("test"),
+	)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
@@ -189,12 +167,10 @@ func TestNewProducer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Producer) {
-		c.AllowEnvironmentBasedConfiguration = false
-		c.Kafka.Brokers = []string{"broker2"}
-	}
-
-	config, err := streamconfig.NewProducer(options)
+	config, err := streamconfig.NewProducer(
+		streamconfig.DisableEnvironmentConfig(),
+		streamconfig.KafkaBroker("broker2"),
+	)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -1,0 +1,308 @@
+package streamconfig
+
+import (
+	"time"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"go.uber.org/zap"
+)
+
+// An Option configures a Consumer and/or Producer.
+type Option interface {
+	apply(*Consumer, *Producer)
+}
+
+// optionFunc wraps a func so it satisfies the Option interface.
+type optionFunc func(*Consumer, *Producer)
+
+func (f optionFunc) apply(c *Consumer, p *Producer) {
+	if c == nil {
+		c = &ConsumerDefaults
+		c.Inmem = inmemconfig.ConsumerDefaults
+		c.Kafka = kafkaconfig.ConsumerDefaults
+		c.Pubsub = pubsubconfig.ConsumerDefaults
+		c.Standardstream = standardstreamconfig.ConsumerDefaults
+	}
+
+	if p == nil {
+		p = &ProducerDefaults
+		p.Inmem = inmemconfig.ProducerDefaults
+		p.Kafka = kafkaconfig.ProducerDefaults
+		p.Pubsub = pubsubconfig.ProducerDefaults
+		p.Standardstream = standardstreamconfig.ProducerDefaults
+	}
+
+	f(c, p)
+}
+
+// ConsumerOptions is a convenience accessor to manually set consumer options.
+func ConsumerOptions(fn func(c *Consumer)) Option {
+	c := &ConsumerDefaults
+	c.Inmem = inmemconfig.ConsumerDefaults
+	c.Kafka = kafkaconfig.ConsumerDefaults
+	c.Pubsub = pubsubconfig.ConsumerDefaults
+	c.Standardstream = standardstreamconfig.ConsumerDefaults
+
+	fn(c)
+
+	return optionFunc(func(c1 *Consumer, _ *Producer) {
+		*c1 = *c
+	})
+}
+
+// ProducerOptions is a convenience accessor to manually set producer options.
+func ProducerOptions(fn func(p *Producer)) Option {
+	p := &ProducerDefaults
+	p.Inmem = inmemconfig.ProducerDefaults
+	p.Kafka = kafkaconfig.ProducerDefaults
+	p.Pubsub = pubsubconfig.ProducerDefaults
+	p.Standardstream = standardstreamconfig.ProducerDefaults
+
+	fn(p)
+
+	return optionFunc(func(_ *Consumer, p1 *Producer) {
+		*p1 = *p
+	})
+}
+
+// DisableEnvironmentConfig prevents the consumer or producer to be configured
+// via environment variables, instead of the default configuration to allow
+// environment variable-based configurations.
+func DisableEnvironmentConfig() Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.AllowEnvironmentBasedConfiguration = false
+		p.AllowEnvironmentBasedConfiguration = false
+	})
+}
+
+// ManualErrorHandling prevents the consumer or producer to automatically
+// handle stream errors. When this option is passed, the application itself
+// needs to listen to, and act on the `Errors()` channel.
+func ManualErrorHandling() Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.HandleErrors = false
+		p.HandleErrors = false
+	})
+}
+
+// ManualInterruptHandling prevents the consumer or producer to automatically
+// handle interrupt signals. When this option is passed, the application itself
+// needs to handle Unix interrupt signals to properly close the consumer or
+// producer when required.
+func ManualInterruptHandling() Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.HandleInterrupt = false
+		p.HandleInterrupt = false
+	})
+}
+
+// Logger sets the logger for the consumer or producer.
+func Logger(l *zap.Logger) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Logger = l
+		p.Logger = l
+	})
+}
+
+// Name sets the name for the consumer or producer.
+func Name(s string) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Name = s
+		p.Name = s
+	})
+}
+
+// InmemStore adds a store to the inmem consumer and producer.
+func InmemStore(s stream.Store) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Inmem.Store = s
+		p.Inmem.Store = s
+	})
+}
+
+// KafkaBroker adds a broker to the list of configured Kafka brokers.
+func KafkaBroker(s string) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.Brokers = append(c.Kafka.Brokers, s)
+		p.Kafka.Brokers = append(p.Kafka.Brokers, s)
+	})
+}
+
+// KafkaCommitInterval sets the consumer's CommitInterval.
+//
+// This option has no effect when applied to a producer.
+func KafkaCommitInterval(d time.Duration) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.CommitInterval = d
+	})
+}
+
+// KafkaCompressionCodec sets the compression codec for the produced messages.
+//
+// // This option has no effect when applied to a consumer.
+func KafkaCompressionCodec(s kafkaconfig.Compression) Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.CompressionCodec = s
+	})
+}
+
+// KafkaDebug enabled debugging for Kafka.
+func KafkaDebug() Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.Debug.All = true
+		p.Kafka.Debug.All = true
+	})
+}
+
+// KafkaGroupID sets the group ID for the consumer.
+//
+// This option has no effect when applied to a producer.
+func KafkaGroupID(s string) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.GroupID = s
+	})
+}
+
+// KafkaHeartbeatInterval sets the consumer or producer HeartbeatInterval.
+func KafkaHeartbeatInterval(d time.Duration) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.HeartbeatInterval = d
+		p.Kafka.HeartbeatInterval = d
+	})
+}
+
+// KafkaID sets the consumer or producer ID.
+func KafkaID(s string) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.ID = s
+		p.Kafka.ID = s
+	})
+}
+
+// KafkaInitialOffset sets the InitialOffset.
+//
+// This option has no effect when applied to a producer.
+func KafkaInitialOffset(s kafkaconfig.Offset) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.InitialOffset = s
+	})
+}
+
+// KafkaMaxDeliveryRetries sets the MaxDeliveryRetries.
+//
+// This option has no effect when applied to a consumer.
+func KafkaMaxDeliveryRetries(i int) Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.MaxDeliveryRetries = i
+	})
+}
+
+// KafkaMaxQueueBufferDuration sets the MaxQueueBufferDuration.
+//
+// This option has no effect when applied to a consumer.
+func KafkaMaxQueueBufferDuration(d time.Duration) Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.MaxQueueBufferDuration = d
+	})
+}
+
+// KafkaMaxQueueSizeKBytes sets the MaxQueueSizeKBytes.
+//
+// This option has no effect when applied to a consumer.
+func KafkaMaxQueueSizeKBytes(i int) Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.MaxQueueSizeKBytes = i
+	})
+}
+
+// KafkaMaxQueueSizeMessages sets the MaxQueueSizeMessages.
+//
+// This option has no effect when applied to a consumer.
+func KafkaMaxQueueSizeMessages(i int) Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.MaxQueueSizeMessages = i
+	})
+}
+
+// KafkaRequireNoAck configures the producer not to wait for any broker acks.
+//
+// This option has no effect when applied to a consumer.
+func KafkaRequireNoAck() Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.RequiredAcks = kafkaconfig.AckNone
+	})
+}
+
+// KafkaRequireLeaderAck configures the producer wait for a single ack by the
+// Kafka cluster leader broker.
+//
+// This option has no effect when applied to a consumer.
+func KafkaRequireLeaderAck() Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.RequiredAcks = kafkaconfig.AckLeader
+	})
+}
+
+// KafkaRequireAllAck configures the producer wait for a acks from all brokers
+// available in the Kafka cluster.
+//
+// This option has no effect when applied to a consumer.
+func KafkaRequireAllAck() Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.RequiredAcks = kafkaconfig.AckAll
+	})
+}
+
+// KafkaSecurityProtocol configures the producer or consumer to use the
+// specified security protocol.
+func KafkaSecurityProtocol(s kafkaconfig.Protocol) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.SecurityProtocol = s
+		p.Kafka.SecurityProtocol = s
+	})
+}
+
+// KafkaSessionTimeout configures the producer or consumer to use the
+// specified session timeout.
+func KafkaSessionTimeout(d time.Duration) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.SessionTimeout = d
+		p.Kafka.SessionTimeout = d
+	})
+}
+
+// KafkaSSL configures the producer or consumer to use the specified SSL config.
+func KafkaSSL(capath, certpath, crlpath, keypassword, keypath, keystorepassword, keystorepath string) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.SSL.CAPath = capath
+		c.Kafka.SSL.CertPath = certpath
+		c.Kafka.SSL.CRLPath = crlpath
+		c.Kafka.SSL.KeyPassword = keypassword
+		c.Kafka.SSL.KeyPath = keypath
+		c.Kafka.SSL.KeystorePassword = keystorepassword
+		c.Kafka.SSL.KeystorePath = keystorepath
+
+		p.Kafka.SSL.CAPath = capath
+		p.Kafka.SSL.CertPath = certpath
+		p.Kafka.SSL.CRLPath = crlpath
+		p.Kafka.SSL.KeyPassword = keypassword
+		p.Kafka.SSL.KeyPath = keypath
+		p.Kafka.SSL.KeystorePassword = keystorepassword
+		p.Kafka.SSL.KeystorePath = keystorepath
+	})
+}
+
+// KafkaTopic configures the producer or consumer to use the specified topic. In
+// case of the consumer, this option can be used multiple times to consume from
+// more than one topic. In case of the producer, the last usage of this option
+// will set the final topic to produce to.
+func KafkaTopic(s string) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.Topics = append(c.Kafka.Topics, s)
+		p.Kafka.Topic = s
+	})
+}

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -1,0 +1,359 @@
+package streamconfig_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/inmemconfig"
+	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
+	"github.com/blendle/go-streamprocessor/streamstore/inmemstore"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		ins      []streamconfig.Option
+		consumer streamconfig.Consumer
+		producer streamconfig.Producer
+	}{
+		"DisableEnvironmentConfig": {
+			[]streamconfig.Option{streamconfig.DisableEnvironmentConfig()},
+			streamconfig.Consumer{
+				AllowEnvironmentBasedConfiguration: false,
+			},
+			streamconfig.Producer{
+				AllowEnvironmentBasedConfiguration: false,
+			},
+		},
+
+		"ManualErrorHandling": {
+			[]streamconfig.Option{streamconfig.ManualErrorHandling()},
+			streamconfig.Consumer{
+				HandleErrors: false,
+			},
+			streamconfig.Producer{
+				HandleErrors: false,
+			},
+		},
+
+		"ManualInterruptHandling": {
+			[]streamconfig.Option{streamconfig.ManualInterruptHandling()},
+			streamconfig.Consumer{
+				HandleInterrupt: false,
+			},
+			streamconfig.Producer{
+				HandleInterrupt: false,
+			},
+		},
+
+		"Logger": {
+			[]streamconfig.Option{streamconfig.Logger(zap.NewNop())},
+			streamconfig.Consumer{
+				Logger: zap.NewNop(),
+			},
+			streamconfig.Producer{
+				Logger: zap.NewNop(),
+			},
+		},
+
+		"Name": {
+			[]streamconfig.Option{streamconfig.Name("test1")},
+			streamconfig.Consumer{
+				Name: "test1",
+			},
+			streamconfig.Producer{
+				Name: "test1",
+			},
+		},
+
+		"InmemStore": {
+			[]streamconfig.Option{streamconfig.InmemStore(inmemstore.New())},
+			streamconfig.Consumer{
+				Inmem: inmemconfig.Consumer{Store: inmemstore.New()},
+			},
+			streamconfig.Producer{
+				Inmem: inmemconfig.Producer{Store: inmemstore.New()},
+			},
+		},
+
+		"KafkaBroker": {
+			[]streamconfig.Option{streamconfig.KafkaBroker("test1")},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Brokers: []string{"test1"}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Brokers: []string{"test1"}},
+			},
+		},
+
+		"KafkaBroker (multiple)": {
+			[]streamconfig.Option{
+				streamconfig.KafkaBroker("test1"),
+				streamconfig.KafkaBroker("test2"),
+			},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Brokers: []string{"test1", "test2"}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Brokers: []string{"test1", "test2"}},
+			},
+		},
+
+		"KafkaCommitInterval": {
+			[]streamconfig.Option{streamconfig.KafkaCommitInterval(1 * time.Second)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{CommitInterval: 1 * time.Second},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaCompressionCodec": {
+			[]streamconfig.Option{streamconfig.KafkaCompressionCodec(kafkaconfig.CompressionGZIP)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{CompressionCodec: kafkaconfig.CompressionGZIP},
+			},
+		},
+
+		"KafkaDebug": {
+			[]streamconfig.Option{streamconfig.KafkaDebug()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Debug: kafkaconfig.Debug{All: true}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Debug: kafkaconfig.Debug{All: true}},
+			},
+		},
+
+		"KafkaGroupID": {
+			[]streamconfig.Option{streamconfig.KafkaGroupID("test1")},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{GroupID: "test1"},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaHeartbeatInterval": {
+			[]streamconfig.Option{streamconfig.KafkaHeartbeatInterval(1 * time.Second)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{HeartbeatInterval: 1 * time.Second},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{HeartbeatInterval: 1 * time.Second},
+			},
+		},
+
+		"KafkaID": {
+			[]streamconfig.Option{streamconfig.KafkaID("test1")},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{ID: "test1"},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{ID: "test1"},
+			},
+		},
+
+		"KafkaInitialOffset": {
+			[]streamconfig.Option{streamconfig.KafkaInitialOffset(kafkaconfig.OffsetEnd)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaMaxDeliveryRetries": {
+			[]streamconfig.Option{streamconfig.KafkaMaxDeliveryRetries(10)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxDeliveryRetries: 10},
+			},
+		},
+
+		"KafkaMaxQueueBufferDuration": {
+			[]streamconfig.Option{streamconfig.KafkaMaxQueueBufferDuration(1 * time.Second)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueBufferDuration: 1 * time.Second},
+			},
+		},
+
+		"KafkaMaxQueueSizeKBytes": {
+			[]streamconfig.Option{streamconfig.KafkaMaxQueueSizeKBytes(1024)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueSizeKBytes: 1024},
+			},
+		},
+
+		"KafkaMaxQueueSizeMessages": {
+			[]streamconfig.Option{streamconfig.KafkaMaxQueueSizeMessages(5000)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxQueueSizeMessages: 5000},
+			},
+		},
+
+		"KafkaRequireNoAck": {
+			[]streamconfig.Option{streamconfig.KafkaRequireNoAck()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckNone},
+			},
+		},
+
+		"KafkaRequireLeaderAck": {
+			[]streamconfig.Option{streamconfig.KafkaRequireLeaderAck()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckLeader},
+			},
+		},
+
+		"KafkaRequireAllAck": {
+			[]streamconfig.Option{streamconfig.KafkaRequireAllAck()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{RequiredAcks: kafkaconfig.AckAll},
+			},
+		},
+
+		"KafkaSecurityProtocol": {
+			[]streamconfig.Option{streamconfig.KafkaSecurityProtocol(kafkaconfig.ProtocolSSL)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SecurityProtocol: kafkaconfig.ProtocolSSL},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SecurityProtocol: kafkaconfig.ProtocolSSL},
+			},
+		},
+
+		"KafkaSessionTimeout": {
+			[]streamconfig.Option{streamconfig.KafkaSessionTimeout(1 * time.Second)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{SessionTimeout: 1 * time.Second},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{SessionTimeout: 1 * time.Second},
+			},
+		},
+
+		"KafkaSSL": {
+			[]streamconfig.Option{streamconfig.KafkaSSL("a", "b", "c", "d", "e", "f", "g")},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{
+					SSL: kafkaconfig.SSL{
+						CAPath:           "a",
+						CertPath:         "b",
+						CRLPath:          "c",
+						KeyPassword:      "d",
+						KeyPath:          "e",
+						KeystorePassword: "f",
+						KeystorePath:     "g",
+					},
+				},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{
+					SSL: kafkaconfig.SSL{
+						CAPath:           "a",
+						CertPath:         "b",
+						CRLPath:          "c",
+						KeyPassword:      "d",
+						KeyPath:          "e",
+						KeystorePassword: "f",
+						KeystorePath:     "g",
+					},
+				},
+			},
+		},
+
+		"KafkaTopic": {
+			[]streamconfig.Option{streamconfig.KafkaTopic("test1")},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{"test1"}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Topic: "test1"},
+			},
+		},
+
+		"KafkaTopic (multiple)": {
+			[]streamconfig.Option{
+				streamconfig.KafkaTopic("test1"),
+				streamconfig.KafkaTopic("test2"),
+			},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{Topics: []string{"test1", "test2"}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{Topic: "test2"},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := streamconfig.Consumer{}
+			p := streamconfig.Producer{}
+
+			assert.EqualValues(t, tt.consumer, c.WithOptions(tt.ins...))
+			assert.EqualValues(t, tt.producer, p.WithOptions(tt.ins...))
+		})
+	}
+}
+
+func TestConsumerOptions(t *testing.T) {
+	opts := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
+		c.Name = "hello world"
+	})
+
+	c1 := streamconfig.Consumer{}
+	c2, _ := streamconfig.NewConsumer()
+	c2.Name = "hello world"
+
+	p := streamconfig.Producer{}
+
+	assert.EqualValues(t, c2, c1.WithOptions(opts))
+	assert.EqualValues(t, streamconfig.Producer{}, p.WithOptions(opts))
+}
+
+func TestProducerOptions(t *testing.T) {
+	opts := streamconfig.ProducerOptions(func(p *streamconfig.Producer) {
+		p.Name = "hello world"
+	})
+
+	p1 := streamconfig.Producer{}
+	p2, _ := streamconfig.NewProducer()
+	p2.Name = "hello world"
+
+	c := streamconfig.Consumer{}
+
+	assert.EqualValues(t, p2, p1.WithOptions(opts))
+	assert.EqualValues(t, streamconfig.Consumer{}, c.WithOptions(opts))
+}

--- a/streamconfig/testing.go
+++ b/streamconfig/testing.go
@@ -13,7 +13,7 @@ import (
 
 // TestNewConsumer returns a new consumer configuration struct, optionally with
 // the default values removed.
-func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) Consumer {
+func TestNewConsumer(tb testing.TB, defaults bool, options ...Option) Consumer {
 	c, err := NewConsumer()
 	require.NoError(tb, err)
 
@@ -30,11 +30,7 @@ func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) C
 	}
 
 	for _, option := range options {
-		if option == nil {
-			continue
-		}
-
-		option(&c)
+		option.apply(&c, nil)
 	}
 
 	err = envconfig.Process(c.Name, &c)
@@ -45,21 +41,23 @@ func TestNewConsumer(tb testing.TB, defaults bool, options ...func(*Consumer)) C
 
 // TestConsumerOptions returns an array of consumer options ready to be used
 // during testing.
-func TestConsumerOptions(tb testing.TB, options ...func(*Consumer)) []func(c *Consumer) {
+func TestConsumerOptions(tb testing.TB, options ...Option) []Option {
 	tb.Helper()
 
-	var defaults []func(c *Consumer)
+	var defaults []Option
 
-	defaults = append(defaults, func(c *Consumer) {
+	config := ConsumerOptions(func(c *Consumer) {
 		c.Kafka = kafkaconfig.TestConsumer(tb)
 	})
+
+	defaults = append(defaults, config)
 
 	return append(defaults, options...)
 }
 
 // TestNewProducer returns a new producer configuration struct, optionally with
 // the default values removed.
-func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) Producer {
+func TestNewProducer(tb testing.TB, defaults bool, options ...Option) Producer {
 	p, err := NewProducer()
 	require.NoError(tb, err)
 
@@ -76,11 +74,7 @@ func TestNewProducer(tb testing.TB, defaults bool, options ...func(*Producer)) P
 	}
 
 	for _, option := range options {
-		if option == nil {
-			continue
-		}
-
-		option(&p)
+		option.apply(nil, &p)
 	}
 
 	err = envconfig.Process(p.Name, &p)

--- a/streamconfig/testing_test.go
+++ b/streamconfig/testing_test.go
@@ -29,12 +29,8 @@ func TestTestNewConsumer_WithOptions(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	options := func(c *streamconfig.Consumer) {
-		c.Logger = logger
-	}
-
 	c1 := streamconfig.Consumer{Logger: logger}
-	c2 := streamconfig.TestNewConsumer(t, false, options)
+	c2 := streamconfig.TestNewConsumer(t, false, streamconfig.Logger(logger))
 
 	assert.EqualValues(t, c1, c2)
 }
@@ -53,13 +49,13 @@ func TestTestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.Brokers = []string{"broker2"}
-		c.Kafka.ID = "test"
+	options := []streamconfig.Option{
+		streamconfig.KafkaBroker("broker2"),
+		streamconfig.KafkaID("test"),
 	}
 
 	c1 := streamconfig.Consumer{Kafka: kafkaconfig.Consumer{Brokers: []string{"broker1"}, ID: "test"}}
-	c2 := streamconfig.TestNewConsumer(t, false, options)
+	c2 := streamconfig.TestNewConsumer(t, false, options...)
 
 	assert.EqualValues(t, c1, c2)
 }
@@ -82,12 +78,8 @@ func TestTestNewProducer_WithOptions(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
-	options := func(c *streamconfig.Producer) {
-		c.Logger = logger
-	}
-
 	p1 := streamconfig.Producer{Logger: logger}
-	p2 := streamconfig.TestNewProducer(t, false, options)
+	p2 := streamconfig.TestNewProducer(t, false, streamconfig.Logger(logger))
 
 	assert.EqualValues(t, p1, p2)
 }
@@ -106,30 +98,18 @@ func TestTestNewProducer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("KAFKA_BROKERS", "broker1")
 	defer os.Unsetenv("KAFKA_BROKERS") // nolint: errcheck
 
-	options := func(c *streamconfig.Producer) {
-		c.Kafka.Brokers = []string{"broker2"}
-		c.Kafka.ID = "test"
+	options := []streamconfig.Option{
+		streamconfig.KafkaBroker("broker2"),
+		streamconfig.KafkaID("test"),
 	}
 
 	c1 := streamconfig.Producer{Kafka: kafkaconfig.Producer{Brokers: []string{"broker1"}, ID: "test"}}
-	c2 := streamconfig.TestNewProducer(t, false, options)
+	c2 := streamconfig.TestNewProducer(t, false, options...)
 
 	assert.EqualValues(t, c1, c2)
 }
 
 func TestTestConsumerOptions(t *testing.T) {
-	options := func(c *streamconfig.Consumer) {
-		c.Kafka.GroupID = "overrideGroup"
-	}
-
-	opts := streamconfig.TestConsumerOptions(t, options)
+	opts := streamconfig.TestConsumerOptions(t, streamconfig.KafkaGroupID("overrideGroup"))
 	require.Len(t, opts, 2)
-
-	c := &streamconfig.Consumer{}
-
-	opts[0](c)
-	assert.Equal(t, c.Kafka.GroupID, "testGroup")
-
-	opts[1](c)
-	assert.Equal(t, c.Kafka.GroupID, "overrideGroup")
 }


### PR DESCRIPTION
I was kind of annoyed at the (useless) verbosity of the configuration API
when configuring a new consumer and/or producer. Especially since 90% of
the stream processors are configured through environment variables
anyway, and only a few have to set elaborate lists of configuration
values in the code.

Right now, it's not uncommon to see the following lines in all
processors:

```golang
consumerOpts := func(c *streamconfig.Consumer) {
  c.Logger = *logger.L
}

consumer, err := streamclient.NewConsumer(consumerOpts)
// handle error

producerOpts := func(c *streamconfig.Producer) {
  c.Logger = *logger.L
}

producer, err := streamclient.NewProducer(producerOpts)
// handle error
```

Like I said, there's a lot of useless verbosity there.

Now, it becomes much simpler/cleaner to do this:

```golang
log := streamconfig.Logger(*logger.L)

consumer, err := streamclient.NewConsumer(log)
// handle error

producer, err := streamclient.NewProducer(log)
// handle error
```

You can still configure multiple options as before, in several different
ways:

1. multiple separate options:

```golang
log := streamconfig.Logger(*logger.L)
name := streamconfig.Name("my processor")

consumer, err := streamclient.NewConsumer(log, name)
// handle error
```

2. multiple options combined:

```golang
opts := []streamconfig.Option{
  streamconfig.Logger(*logger.L),
  streamconfig.Name("my processor"),
}

consumer, err := streamclient.NewConsumer(opts...)
// handle error
```

3. multiple options per consumer/producer:

```golang
consumerOpts := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
  c.Logger = *logger.L
  c.Name = "my processor"
})

consumer, err := streamclient.NewConsumer(consumerOpts)
// handle error
```

4. a combination of shared configuration, and consumer/producer specific:

```golang
opts := streamconfig.Options(func(c *streamconfig.Consumer, p *streamconfig.Producer) {
  c.Logger = *logger.L
  c.Name = "my processor"
  c.Kafka.Broker = "broker-1"

  p.Logger = *logger.L
  p.Name = "my processor"
  p.Kafka.Broker = "broker-1"
})

consumer, err := streamclient.NewConsumer(opts, streamclient.KafkaTopic("my-topic-1"))
// handle error

producer, err := streamclient.NewProducer(opts, streamclient.KafkaTopic("my-topic-2"))
// handle error
```

There are still things to be improved, but at least this brings the
configuration API to a more acceptable level.
