### PR TITLE
Add extra check to prevent setting empty topic names

### DIFF
--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -168,6 +168,12 @@ func (c *Consumer) validate() error {
 		return errors.New("required config Kafka.Topics empty")
 	}
 
+	for i := range c.Topics {
+		if len(c.Topics[i]) == 0 {
+			return errors.New("empty value detected in config Kafka.Topics")
+		}
+	}
+
 	if len(c.GroupID) == 0 {
 		return errors.New("required config Kafka.GroupID missing")
 	}

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -293,9 +293,19 @@ func TestConsumer_ConfigMap_Validation(t *testing.T) {
 			&kafkaconfig.Consumer{Brokers: []string{"1"}, Topics: []string{}, GroupID: "1"},
 		},
 
-		"groupID": {
+		"topics (empty value)": {
+			false,
+			&kafkaconfig.Consumer{Brokers: []string{"1"}, Topics: []string{""}, GroupID: "1"},
+		},
+
+		"groupID (missing)": {
 			false,
 			&kafkaconfig.Consumer{Brokers: []string{"1"}, Topics: []string{"1"}},
+		},
+
+		"groupID (empty)": {
+			false,
+			&kafkaconfig.Consumer{Brokers: []string{"1"}, GroupID: "", Topics: []string{"1"}},
 		},
 	}
 


### PR DESCRIPTION
While working on https://github.com/blendle/go-streamprocessor/pull/69, I got into a weird test state where a consumer was configured with an empty topic string, this shouldn't be possible.