### PR TITLE
Add `streamutil.Interrupt()` function

### DIFF
--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -64,7 +64,7 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 1)
+		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -64,7 +64,7 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 1)
+		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -70,7 +70,7 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 1)
+		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -79,7 +79,7 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 1)
+		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -71,7 +71,7 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 1)
+		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -67,7 +67,7 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 1)
+		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 

--- a/streamutil/interrupt.go
+++ b/streamutil/interrupt.go
@@ -3,10 +3,23 @@ package streamutil
 import (
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
 )
+
+// Interrupt returns a channel that receives a signal when the application
+// receives either an SIGINT or SIGTERM signal. This is provided for convenience
+// when dealing with a select statement and receiving stream messages, making it
+// easy to cleanly exit after fully handling one message, but before handling
+// the next message.
+func Interrupt() <-chan os.Signal {
+	ch := make(chan os.Signal, 3)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+
+	return ch
+}
 
 // HandleInterrupts monitors for an interrupt signal, and calls the provided
 // closer function once received. It has a built-in timeout capability to force

--- a/streamutil/interrupt.go
+++ b/streamutil/interrupt.go
@@ -26,7 +26,7 @@ func Interrupt() <-chan os.Signal {
 // terminate the application when the closer takes too long to close, or returns
 // an error during closing.
 func HandleInterrupts(signals chan os.Signal, closer func() error, logger *zap.Logger) {
-	signal.Notify(signals, os.Interrupt)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 
 	s, ok := <-signals
 	if !ok {
@@ -34,7 +34,7 @@ func HandleInterrupts(signals chan os.Signal, closer func() error, logger *zap.L
 	}
 
 	logger.Info(
-		"Got interrupt signal, cleaning up. Use ^C again to exit immediately.",
+		"Got interrupt signal, cleaning up. Use ^C to exit immediately.",
 		zap.String("signal", s.String()),
 	)
 

--- a/streamutil/interrupt_test.go
+++ b/streamutil/interrupt_test.go
@@ -1,8 +1,11 @@
 package streamutil_test
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -11,6 +14,37 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+func TestInterrupt(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("BE_TESTING_FATAL") == "1" {
+		select {
+		case s := <-streamutil.Interrupt():
+			println("interrupt received:", s.String())
+			return
+		case <-time.After(1 * time.Second):
+			os.Exit(1)
+		}
+
+		return
+	}
+
+	for _, sig := range []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT} {
+		cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+		cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+
+		var b bytes.Buffer
+		cmd.Stderr = bufio.NewWriter(&b)
+		require.NoError(t, cmd.Start())
+		time.Sleep(100 * time.Millisecond)
+
+		require.NoError(t, cmd.Process.Signal(sig))
+		require.NoError(t, cmd.Wait())
+
+		assert.Contains(t, b.String(), "interrupt received: "+sig.String())
+	}
+}
 
 func TestHandleInterrupts(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
While not _directly_ related to streams or stream processors, interrupt
handling is a _very_ important aspect of stream processing, as you want as
much control over when you stop your processor as possible.

This is why this library has had correct "default" interrupt behavior
from the start (essentially cleanly closing any open consumers or
producers when required).

However, cleanly closing a producer or consumer is not always enough, as
your business logic is very much a driving factor in dictating what the
"correct" behavior is when an interrupt or kill signal is received.

For example, if your business logic reaches out into data stores other
than the streams you are consuming from or producing to, you might want to
wait for those actions to be finished cleanly, before stopping your
application.

You already have control over whether or not use the built-in signal
handling by explicitly disabling it, like so:

```golang
streamclient.NewConsumer(streamconfig.ManualInterruptHandling())
```

At this point, interrupt handling would be disabled, and you'd have to
manually manage interrupts. It's not like this is hard to do, but this
function makes it a tiny bit easier in the context of a select statement
which loops over incoming stream messages, like so:

```golang
for {
  select {
  case msg := <-c.Messages():
    // handle the incoming message, we'll consider any business logic
    // inside this case statement as a loose transaction, and want to
    // make sure it finishes before we terminate the application.

  case <-streamutil.Interrupt():
    // at this point, we've received an interrupt signal, and we also
    // know that the previous message processing finished, and any
    // future message processing is on hold. We can now cleanly exit.
    return
  }
}
```

The above code is thread-safe: if you have multiple goroutines handling
multiple consumed topics, you can call this function in all of those
goroutines, and you'll receive the interrupt signal in each of them for
you to act on as you please.