### PR TITLE
Add support for absolute (tailing) default offsets

### DIFF
--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -123,24 +123,38 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{ID: "hi!"}},
 		},
 
-		"Kafka.InitialOffset (beginning)": {
-			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "beginning"},
+		"Kafka.OffsetDefault (positive)": {
+			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "10"},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetBeginning},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: 10},
 			},
 		},
 
-		"Kafka.InitialOffset (end)": {
-			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "end"},
+		"Kafka.OffsetDefault (negative)": {
+			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "-10"},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: -10},
 			},
 		},
 
-		"Kafka.InitialOffset (capitalized)": {
-			map[string]string{"CONSUMER_KAFKA_INITIAL_OFFSET": "End"},
+		"Kafka.OffsetInitial (beginning)": {
+			map[string]string{"CONSUMER_KAFKA_OFFSET_INITIAL": "beginning"},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+				Kafka: kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetBeginning},
+			},
+		},
+
+		"Kafka.OffsetInitial (end)": {
+			map[string]string{"CONSUMER_KAFKA_OFFSET_INITIAL": "end"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetEnd},
+			},
+		},
+
+		"Kafka.OffsetInitial (capitalized)": {
+			map[string]string{"CONSUMER_KAFKA_OFFSET_INITIAL": "End"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetEnd},
 			},
 		},
 

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -29,7 +29,8 @@ func TestConsumer(t *testing.T) {
 		GroupID:           "",
 		HeartbeatInterval: time.Duration(0),
 		ID:                "",
-		InitialOffset:     kafkaconfig.OffsetBeginning,
+		OffsetInitial:     kafkaconfig.OffsetBeginning,
+		OffsetDefault:     5,
 		SecurityProtocol:  kafkaconfig.ProtocolPlaintext,
 		SessionTimeout:    time.Duration(0),
 		SSL:               kafkaconfig.SSL{KeyPath: ""},
@@ -45,7 +46,7 @@ func TestConsumerDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, config.CommitInterval)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
-	assert.Equal(t, kafkaconfig.OffsetBeginning, config.InitialOffset)
+	assert.Equal(t, kafkaconfig.OffsetBeginning, config.OffsetInitial)
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
 }
@@ -137,13 +138,18 @@ func TestConsumer_ConfigMap(t *testing.T) {
 			&kafka.ConfigMap{},
 		},
 
-		"initialOffset (end)": {
-			&kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
+		"offsetDefault": {
+			&kafkaconfig.Consumer{OffsetDefault: 12},
+			&kafka.ConfigMap{},
+		},
+
+		"offsetInitial (end)": {
+			&kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetEnd},
 			&kafka.ConfigMap{"default.topic.config": kafka.ConfigMap{"auto.offset.reset": "end"}},
 		},
 
-		"initialOffset (beginning)": {
-			&kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetBeginning},
+		"offsetInitial (beginning)": {
+			&kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetBeginning},
 			&kafka.ConfigMap{"default.topic.config": kafka.ConfigMap{"auto.offset.reset": "beginning"}},
 		},
 

--- a/streamconfig/kafkaconfig/testing.go
+++ b/streamconfig/kafkaconfig/testing.go
@@ -21,7 +21,7 @@ func TestConsumer(tb testing.TB) Consumer {
 	config.GroupID = "testGroup"
 	config.HeartbeatInterval = 150 * time.Millisecond
 	config.ID = "testConsumer"
-	config.InitialOffset = OffsetBeginning
+	config.OffsetInitial = OffsetBeginning
 	config.SecurityProtocol = ProtocolPlaintext
 	config.SessionTimeout = 1 * time.Second
 	config.Topics = []string{"testTopic"}

--- a/streamconfig/kafkaconfig/testing_test.go
+++ b/streamconfig/kafkaconfig/testing_test.go
@@ -17,7 +17,7 @@ func TestTestConsumer(t *testing.T) {
 	assert.Equal(t, "testGroup", c.GroupID)
 	assert.Equal(t, time.Duration(150*time.Millisecond), c.HeartbeatInterval)
 	assert.Equal(t, "testConsumer", c.ID)
-	assert.Equal(t, OffsetBeginning, c.InitialOffset)
+	assert.Equal(t, OffsetBeginning, c.OffsetInitial)
 	assert.Equal(t, ProtocolPlaintext, c.SecurityProtocol)
 	assert.Equal(t, 1*time.Second, c.SessionTimeout)
 	assert.Equal(t, []string{"testTopic"}, c.Topics)

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -221,7 +221,7 @@ func KafkaMaxQueueSizeMessages(i int) Option {
 // KafkaOffsetHead sets the OffsetDefault.
 //
 // This option has no effect when applied to a producer.
-func KafkaOffsetHead(i uint64) Option {
+func KafkaOffsetHead(i uint32) Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
 		c.Kafka.OffsetDefault = int64(i)
 	})
@@ -239,7 +239,7 @@ func KafkaOffsetInitial(s kafkaconfig.Offset) Option {
 // KafkaOffsetTail sets the OffsetDefault.
 //
 // This option has no effect when applied to a producer.
-func KafkaOffsetTail(i uint64) Option {
+func KafkaOffsetTail(i uint32) Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
 		c.Kafka.OffsetDefault = -int64(i)
 	})

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -182,15 +182,6 @@ func KafkaID(s string) Option {
 	})
 }
 
-// KafkaInitialOffset sets the InitialOffset.
-//
-// This option has no effect when applied to a producer.
-func KafkaInitialOffset(s kafkaconfig.Offset) Option {
-	return optionFunc(func(c *Consumer, p *Producer) {
-		c.Kafka.InitialOffset = s
-	})
-}
-
 // KafkaMaxDeliveryRetries sets the MaxDeliveryRetries.
 //
 // This option has no effect when applied to a consumer.
@@ -224,6 +215,33 @@ func KafkaMaxQueueSizeKBytes(i int) Option {
 func KafkaMaxQueueSizeMessages(i int) Option {
 	return optionFunc(func(_ *Consumer, p *Producer) {
 		p.Kafka.MaxQueueSizeMessages = i
+	})
+}
+
+// KafkaOffsetHead sets the OffsetDefault.
+//
+// This option has no effect when applied to a producer.
+func KafkaOffsetHead(i uint64) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.OffsetDefault = int64(i)
+	})
+}
+
+// KafkaOffsetInitial sets the OffsetInitial.
+//
+// This option has no effect when applied to a producer.
+func KafkaOffsetInitial(s kafkaconfig.Offset) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.OffsetInitial = s
+	})
+}
+
+// KafkaOffsetTail sets the OffsetDefault.
+//
+// This option has no effect when applied to a producer.
+func KafkaOffsetTail(i uint64) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.OffsetDefault = -int64(i)
 	})
 }
 

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -175,16 +175,6 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
-		"KafkaInitialOffset": {
-			[]streamconfig.Option{streamconfig.KafkaInitialOffset(kafkaconfig.OffsetEnd)},
-			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{InitialOffset: kafkaconfig.OffsetEnd},
-			},
-			streamconfig.Producer{
-				Kafka: kafkaconfig.Producer{},
-			},
-		},
-
 		"KafkaMaxDeliveryRetries": {
 			[]streamconfig.Option{streamconfig.KafkaMaxDeliveryRetries(10)},
 			streamconfig.Consumer{
@@ -222,6 +212,36 @@ func TestOptions(t *testing.T) {
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{MaxQueueSizeMessages: 5000},
+			},
+		},
+
+		"KafkaOffsetHead": {
+			[]streamconfig.Option{streamconfig.KafkaOffsetHead(10)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetDefault: 10},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaOffsetInitial": {
+			[]streamconfig.Option{streamconfig.KafkaOffsetInitial(kafkaconfig.OffsetEnd)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetInitial: kafkaconfig.OffsetEnd},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaOffsetTail": {
+			[]streamconfig.Option{streamconfig.KafkaOffsetTail(10)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetDefault: -10},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
 			},
 		},
 

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -1,6 +1,7 @@
 package streamconfig_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -225,6 +226,16 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
+		"KafkaOffsetHead (MaxUint32)": {
+			[]streamconfig.Option{streamconfig.KafkaOffsetHead(math.MaxUint32)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetDefault: int64(math.MaxUint32)},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
 		"KafkaOffsetInitial": {
 			[]streamconfig.Option{streamconfig.KafkaOffsetInitial(kafkaconfig.OffsetEnd)},
 			streamconfig.Consumer{
@@ -239,6 +250,16 @@ func TestOptions(t *testing.T) {
 			[]streamconfig.Option{streamconfig.KafkaOffsetTail(10)},
 			streamconfig.Consumer{
 				Kafka: kafkaconfig.Consumer{OffsetDefault: -10},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaOffsetTail (MaxUint32)": {
+			[]streamconfig.Option{streamconfig.KafkaOffsetTail(math.MaxUint32)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{OffsetDefault: -int64(math.MaxUint32)},
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},


### PR DESCRIPTION
This allows you to set an `OffsetDefault` for kafka. There are two
different meanings for this value, depending on if you provide a positive
or a negative integer.

A positive integer means "start consuming from this exact offset value".

A negative integer means "start consuming from the end, minus this value".

For easy configuration, these can be set using the following two options:

    streamconfig.KafkaOffsetHead(i uint32)
    streamconfig.KafkaOffsetTail(i uint32)

There are two important things to note here:

First, this configuration is inherently different from the `OffsetInitial`
property supported by Kafka. The initial property is defined as follows:

> Action to take when there is no initial offset in offset store or the
> desired offset is out of range

Meaning that this value will be used whenever no offset is stored at the
Kafka brokers, or when the desired offset is out of range. There are only
two values Kafka supports here: start from the beginning, or start from
the end. For these, we already have `kafkaconfig.OffsetBeginning`, and
`kafkaconfig.OffsetEnd`.

Which brings us to the second point. The only way to set a specific offset
for the consumer to use as a starting point, is to overwrite the offset
assigned by the broker to the consumer. This means that normally, if you'd
set a hard-coded offset (either a direct offset, or a "tailing" offset),
whatever offset is known by the brokers for the provided consumer group
would simply be ignored, and starting the consumer twice, would result in
the consumer starting to read from the exact same offset each time.

To follow the principle of least surprise, that's not how this library
handles these values. In this case, as the name `OffsetDefault` implies,
if the configured consumer group already has an offset stored for the
provided topic at the brokers, it will use _that_ offset, instead of
whatever you pass in as the default offset. If however the brokers have no
known offset stored, it will start at the default configured offset, and
once the first offset commit is sent to Kafka, the next time the consumer
is started with the exact same configuration, it will start from the
offset known at the broker, not the default offset configured.