### PR TITLE
Add support for `KafkaGroupIDRandom` option

### DIFF
--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -1,7 +1,10 @@
 package streamconfig
 
 import (
+	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"time"
 
 	"github.com/blendle/go-streamprocessor/stream"
@@ -163,6 +166,23 @@ func KafkaDebug() Option {
 func KafkaGroupID(s string) Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
 		c.Kafka.GroupID = s
+	})
+}
+
+// KafkaGroupIDRandom sets the group ID for the consumer to a random ID. This
+// can be used to configure one-off consumers that should not share their state
+// in a consumer group. The passed in value is used as the seed for the random
+// number generator. For true randomness, pass in `time.Now().Unix()`.
+//
+// This option has no effect when applied to a producer.
+func KafkaGroupIDRandom(i int64) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		// Note: we should probably not do this globally.
+		//
+		// see: https://nishanths.svbtle.com/do-not-seed-the-global-random
+		rand.Seed(i)
+
+		c.Kafka.GroupID = fmt.Sprintf("processor-%d", rand.Intn(math.MaxInt64))
 	})
 }
 

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -156,6 +156,26 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
+		"KafkaGroupIDRandom (seed 0)": {
+			[]streamconfig.Option{streamconfig.KafkaGroupIDRandom(0)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{GroupID: "processor-8717895732742165505"},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaGroupIDRandom (seed 1)": {
+			[]streamconfig.Option{streamconfig.KafkaGroupIDRandom(1)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{GroupID: "processor-5577006791947779410"},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
 		"KafkaHeartbeatInterval": {
 			[]streamconfig.Option{streamconfig.KafkaHeartbeatInterval(1 * time.Second)},
 			streamconfig.Consumer{


### PR DESCRIPTION
The `streamconfig.KafkaGroupIDRandom()` option allows you to easily assign
a random group ID to the consumer every time you start that consumer.

This is useful for one-off consumers that aren't allowed to share consumer
group state with other consumers, or between runs.

This can be used in combination with `streamconfig.KafkaOffsetHead()` or
`streamconfig.KafkaOffsetTail()` to make sure the consumer starts reading
from that configured offset every time you start the consumer, instead of
picking up where it left off in the previous consumer group ID.

A concrete example would be if you want to always get the last message in
a specific topic. To do this, you would provide the following two options:

    streamconfig.KafkaGroupIDRandom()
    streamconfig.KafkaOffsetTail(1)