### PR TITLE
Increase delivery retries and add option to guarantee delivery ordering

### DIFF
--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -123,6 +123,13 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 			streamconfig.Consumer{Kafka: kafkaconfig.Consumer{ID: "hi!"}},
 		},
 
+		"Kafka.MaxInFlightRequests": {
+			map[string]string{"CONSUMER_KAFKA_MAX_IN_FLIGHT_REQUESTS": "10"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{MaxInFlightRequests: 10},
+			},
+		},
+
 		"Kafka.OffsetDefault (positive)": {
 			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "10"},
 			streamconfig.Consumer{

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -48,6 +48,13 @@ type Consumer struct {
 	// request logging.
 	ID string `kafka:"client.id,omitempty" envconfig:"client_id"`
 
+	// MaxInFlightRequests dictates the maximum number of in-flight requests per
+	// broker connection. This is a generic property applied to all broker
+	// communication, however it is primarily relevant to produce requests. In
+	// particular, note that other mechanisms limit the number of outstanding
+	// consumer fetch request per broker to one.
+	MaxInFlightRequests int `kafka:"max.in.flight.requests.per.connection,omitempty" split_words:"true"` // nolint: lll
+
 	// OffsetDefault sets an offset starting point from which to consume messages.
 	// If this value is set to zero (0), the value is ignored, and the
 	// `OffsetInitial` is used instead (see its description for more details). If
@@ -155,13 +162,14 @@ type staticConsumer struct {
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	CommitInterval:    5 * time.Second,
-	Debug:             Debug{},
-	HeartbeatInterval: 1 * time.Second,
-	OffsetInitial:     OffsetBeginning,
-	SecurityProtocol:  ProtocolPlaintext,
-	SessionTimeout:    30 * time.Second,
-	SSL:               SSL{},
+	CommitInterval:      5 * time.Second,
+	Debug:               Debug{},
+	HeartbeatInterval:   1 * time.Second,
+	MaxInFlightRequests: 1000000,
+	OffsetInitial:       OffsetBeginning,
+	SecurityProtocol:    ProtocolPlaintext,
+	SessionTimeout:      30 * time.Second,
+	SSL:                 SSL{},
 }
 
 var staticConsumerDefaults = &staticConsumer{

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -23,18 +23,19 @@ func TestConsumer(t *testing.T) {
 	t.Parallel()
 
 	_ = kafkaconfig.Consumer{
-		Brokers:           []string{},
-		CommitInterval:    time.Duration(0),
-		Debug:             kafkaconfig.Debug{All: true},
-		GroupID:           "",
-		HeartbeatInterval: time.Duration(0),
-		ID:                "",
-		OffsetInitial:     kafkaconfig.OffsetBeginning,
-		OffsetDefault:     5,
-		SecurityProtocol:  kafkaconfig.ProtocolPlaintext,
-		SessionTimeout:    time.Duration(0),
-		SSL:               kafkaconfig.SSL{KeyPath: ""},
-		Topics:            []string{},
+		Brokers:             []string{},
+		CommitInterval:      time.Duration(0),
+		Debug:               kafkaconfig.Debug{All: true},
+		GroupID:             "",
+		HeartbeatInterval:   time.Duration(0),
+		ID:                  "",
+		MaxInFlightRequests: 0,
+		OffsetInitial:       kafkaconfig.OffsetBeginning,
+		OffsetDefault:       5,
+		SecurityProtocol:    kafkaconfig.ProtocolPlaintext,
+		SessionTimeout:      time.Duration(0),
+		SSL:                 kafkaconfig.SSL{KeyPath: ""},
+		Topics:              []string{},
 	}
 }
 
@@ -46,6 +47,7 @@ func TestConsumerDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, config.CommitInterval)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
+	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, kafkaconfig.OffsetBeginning, config.OffsetInitial)
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
@@ -136,6 +138,11 @@ func TestConsumer_ConfigMap(t *testing.T) {
 		"ID (empty)": {
 			&kafkaconfig.Consumer{ID: ""},
 			&kafka.ConfigMap{},
+		},
+
+		"maxInFlightRequests": {
+			&kafkaconfig.Consumer{MaxInFlightRequests: 10},
+			&kafka.ConfigMap{"max.in.flight.requests.per.connection": 10},
 		},
 
 		"offsetDefault": {

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -53,6 +53,13 @@ type Producer struct {
 	// prevent accidental message reordering.
 	MaxDeliveryRetries int `kafka:"message.send.max.retries" split_words:"true"`
 
+	// MaxInFlightRequests dictates the maximum number of in-flight requests per
+	// broker connection. This is a generic property applied to all broker
+	// communication, however it is primarily relevant to produce requests. In
+	// particular, note that other mechanisms limit the number of outstanding
+	// consumer fetch request per broker to one.
+	MaxInFlightRequests int `kafka:"max.in.flight.requests.per.connection,omitempty" split_words:"true"` // nolint: lll
+
 	// MaxQueueBufferDuration is the delay to wait for messages in the producer
 	// queue to accumulate before constructing message batches (MessageSets) to
 	// transmit to brokers. A higher value allows larger and more effective (less
@@ -122,6 +129,7 @@ var ProducerDefaults = Producer{
 	Debug:                  Debug{},
 	HeartbeatInterval:      1 * time.Second,
 	MaxDeliveryRetries:     0,
+	MaxInFlightRequests:    1000000,
 	MaxQueueBufferDuration: time.Duration(0),
 	MaxQueueSizeKBytes:     2097151,
 	MaxQueueSizeMessages:   1000000,

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -49,8 +49,8 @@ type Producer struct {
 	ID string `kafka:"client.id,omitempty" envconfig:"client_id"`
 
 	// MaxDeliveryRetries dictates how many times to retry sending a failing
-	// MessageSet. Note: retrying may cause reordering. Defaults to 0 retries to
-	// prevent accidental message reordering.
+	// MessageSet. Note: retrying may cause reordering. Defaults to 2 retries. Use
+	// `streamconfig.KafkaOrderedDelivery()` to guarantee order delivery.
 	MaxDeliveryRetries int `kafka:"message.send.max.retries" split_words:"true"`
 
 	// MaxInFlightRequests dictates the maximum number of in-flight requests per
@@ -128,7 +128,7 @@ var ProducerDefaults = Producer{
 	CompressionCodec:       CompressionSnappy,
 	Debug:                  Debug{},
 	HeartbeatInterval:      1 * time.Second,
-	MaxDeliveryRetries:     0,
+	MaxDeliveryRetries:     2,
 	MaxInFlightRequests:    1000000,
 	MaxQueueBufferDuration: time.Duration(0),
 	MaxQueueSizeKBytes:     2097151,

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -31,6 +31,7 @@ func TestProducer(t *testing.T) {
 		HeartbeatInterval:      time.Duration(0),
 		ID:                     "",
 		MaxDeliveryRetries:     0,
+		MaxInFlightRequests:    0,
 		MaxQueueBufferDuration: time.Duration(0),
 		MaxQueueSizeKBytes:     0,
 		MaxQueueSizeMessages:   0,
@@ -52,6 +53,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, 0, config.MaxDeliveryRetries)
+	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, 0*time.Second, config.MaxQueueBufferDuration)
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)
 	assert.Equal(t, 1000000, config.MaxQueueSizeMessages)
@@ -150,6 +152,11 @@ func TestProducer_ConfigMap(t *testing.T) {
 		"maxDeliveryRetries": {
 			&kafkaconfig.Producer{MaxDeliveryRetries: 10},
 			&kafka.ConfigMap{"message.send.max.retries": 10},
+		},
+
+		"maxInFlightRequests": {
+			&kafkaconfig.Producer{MaxInFlightRequests: 10},
+			&kafka.ConfigMap{"max.in.flight.requests.per.connection": 10},
 		},
 
 		"maxDeliveryRetries (no omitempty)": {

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -52,7 +52,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
-	assert.Equal(t, 0, config.MaxDeliveryRetries)
+	assert.Equal(t, 2, config.MaxDeliveryRetries)
 	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, 0*time.Second, config.MaxQueueBufferDuration)
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -211,6 +211,15 @@ func KafkaMaxDeliveryRetries(i int) Option {
 	})
 }
 
+// KafkaMaxInFlightRequests sets the maximum allowed in-flight requests for both
+// consumers and producers.
+func KafkaMaxInFlightRequests(i int) Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.MaxInFlightRequests = i
+		p.Kafka.MaxInFlightRequests = i
+	})
+}
+
 // KafkaMaxQueueBufferDuration sets the MaxQueueBufferDuration.
 //
 // This option has no effect when applied to a consumer.

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -274,6 +274,19 @@ func KafkaOffsetTail(i uint32) Option {
 	})
 }
 
+// KafkaOrderedDelivery sets `MaxInFlightRequests` to `1` for the producer, to
+// guarantee ordered delivery of messages.
+//
+// see: https://git.io/vpgiV
+// see: https://git.io/vpgDg
+//
+// This option has no effect when applied to a consumer.
+func KafkaOrderedDelivery() Option {
+	return optionFunc(func(_ *Consumer, p *Producer) {
+		p.Kafka.MaxInFlightRequests = 1
+	})
+}
+
 // KafkaRequireNoAck configures the producer not to wait for any broker acks.
 //
 // This option has no effect when applied to a consumer.

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -296,6 +296,16 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
+		"KafkaOrderedDelivery": {
+			[]streamconfig.Option{streamconfig.KafkaOrderedDelivery()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxInFlightRequests: 1},
+			},
+		},
+
 		"KafkaRequireNoAck": {
 			[]streamconfig.Option{streamconfig.KafkaRequireNoAck()},
 			streamconfig.Consumer{

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -206,6 +206,16 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
+		"KafkaMaxInFlightRequests": {
+			[]streamconfig.Option{streamconfig.KafkaMaxInFlightRequests(10)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{MaxInFlightRequests: 10},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{MaxInFlightRequests: 10},
+			},
+		},
+
 		"KafkaMaxQueueBufferDuration": {
 			[]streamconfig.Option{streamconfig.KafkaMaxQueueBufferDuration(1 * time.Second)},
 			streamconfig.Consumer{


### PR DESCRIPTION
- [x] Add MaxInFlightRequests option for Kafka
- [x]  Add `streamconfig.KafkaOrderedDelivery()` option

  This is a convenience option to set `MaxInFlightRequests` to 1 for the
  producer (NOT the consumer), to guarantee ordered message delivery.

- [x] Set MaxDeliveryRetries to the default value of 2

  This was set to 0 to guarantee delivery ordering, but with the
  introduction of `MaxInFlightRequests` and the convenience option
  `streamconfig.KafkaOrderedDelivery()`, this can now be set back
  to rdkafka's default of 2 retries per delivery.

For more details on this, see these two links:

* https://git.io/vpgiV
* https://git.io/vpgDg

