### PR TITLE
Fix panic closing client with manual interrupts

### DIFF
--- a/streamclient/inmemclient/consumer.go
+++ b/streamclient/inmemclient/consumer.go
@@ -64,7 +64,6 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 
@@ -187,6 +186,7 @@ func newConsumer(options []streamconfig.Option) (*consumer, error) {
 		errors:   make(chan error),
 		quit:     make(chan bool),
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return c, nil

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -177,6 +177,31 @@ func TestConsumer_Close(t *testing.T) {
 	}
 }
 
+func TestConsumer_Close_WithoutInterrupt(t *testing.T) {
+	t.Parallel()
+
+	consumer, err := inmemclient.NewConsumer(
+		streamconfig.InmemListen(),
+		streamconfig.ManualInterruptHandling(),
+	)
+	require.NoError(t, err)
+
+	ch := make(chan error)
+	go func() {
+		ch <- consumer.Close() // Close is working as expected, and the consumer is terminated.
+		ch <- consumer.Close() // Close should return nil immediately, due to `sync.Once`.
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+			t.Fatal("timeout while waiting for close to finish")
+		}
+	}
+}
+
 func BenchmarkConsumer_Messages(b *testing.B) {
 	store := inmemstore.New()
 	line := `{"number":%d}` + "\n"

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -58,7 +58,7 @@ func TestConsumer_Messages(t *testing.T) {
 func TestConsumer_Messages_Ordering(t *testing.T) {
 	t.Parallel()
 
-	messageCount := 100000
+	messageCount := 10000
 	store := inmemstore.New()
 
 	for i := 0; i < messageCount; i++ {
@@ -82,7 +82,7 @@ func TestConsumer_Messages_Ordering(t *testing.T) {
 func TestConsumer_Messages_PerMessageMemoryAllocation(t *testing.T) {
 	t.Parallel()
 
-	messageCount := 100000
+	messageCount := 10000
 	store := inmemstore.New()
 	line := `{"number":%d}` + "\n"
 
@@ -171,7 +171,7 @@ func TestConsumer_Close(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}
@@ -196,7 +196,7 @@ func TestConsumer_Close_WithoutInterrupt(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}

--- a/streamclient/inmemclient/producer.go
+++ b/streamclient/inmemclient/producer.go
@@ -64,7 +64,6 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 
@@ -137,6 +136,7 @@ func newProducer(ch chan stream.Message, options []streamconfig.Option) (*produc
 		errors:   make(chan error),
 		messages: ch,
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return p, nil

--- a/streamclient/inmemclient/producer_test.go
+++ b/streamclient/inmemclient/producer_test.go
@@ -51,10 +51,10 @@ func TestProducer_Messages(t *testing.T) {
 	assert.Equal(t, expected, string(messages[0].Value))
 }
 
-func TestProducer_MessageOrdering(t *testing.T) {
+func TestProducer_Messages_Ordering(t *testing.T) {
 	t.Parallel()
 
-	messageCount := 100000
+	messageCount := 10000
 	store := inmemstore.New()
 	producer, closer := inmemclient.TestProducer(t, store)
 	defer closer()
@@ -114,7 +114,7 @@ func TestProducer_Close(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}
@@ -136,7 +136,7 @@ func TestProducer_Close_WithoutInterrupt(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}

--- a/streamclient/kafkaclient/consumer.go
+++ b/streamclient/kafkaclient/consumer.go
@@ -70,7 +70,6 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 
@@ -280,6 +279,7 @@ func newConsumer(options []streamconfig.Option) (*consumer, error) {
 		messages: make(chan stream.Message),
 		quit:     make(chan bool, 1),
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return c, nil

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -39,7 +39,6 @@ func TestIntegrationNewConsumer_WithOptions(t *testing.T) {
 	topicAndGroup := testutil.Random(t)
 
 	opts := streamconfig.ConsumerOptions(func(c *streamconfig.Consumer) {
-		c.Kafka.Debug.Msg = true
 		c.Kafka.SSL.KeyPassword = "test"
 	})
 
@@ -50,7 +49,6 @@ func TestIntegrationNewConsumer_WithOptions(t *testing.T) {
 	defer func() { require.NoError(t, consumer.Close()) }()
 
 	assert.Equal(t, false, consumer.Config().(streamconfig.Consumer).Kafka.Debug.Broker)
-	assert.Equal(t, true, consumer.Config().(streamconfig.Consumer).Kafka.Debug.Msg)
 	assert.Equal(t, "test", consumer.Config().(streamconfig.Consumer).Kafka.SSL.KeyPassword)
 }
 
@@ -74,7 +72,7 @@ func TestIntegrationConsumer_Close(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}
@@ -100,7 +98,7 @@ func TestIntegrationConsumer_Close_WithoutInterrupt(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -79,7 +79,6 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 
@@ -216,6 +215,7 @@ func newProducer(ch chan stream.Message, options []streamconfig.Option) (*produc
 		messages: ch,
 		quit:     make(chan bool),
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return p, nil

--- a/streamclient/kafkaclient/producer_test.go
+++ b/streamclient/kafkaclient/producer_test.go
@@ -73,7 +73,7 @@ func TestIntegrationProducer_Close(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}
@@ -99,7 +99,7 @@ func TestIntegrationProducer_Close_WithoutInterrupt(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}

--- a/streamclient/kafkaclient/producer_test.go
+++ b/streamclient/kafkaclient/producer_test.go
@@ -53,6 +53,58 @@ func TestIntegrationNewProducer_WithOptions(t *testing.T) {
 	assert.Equal(t, "test", producer.Config().(streamconfig.Producer).Kafka.SSL.KeyPassword)
 }
 
+func TestIntegrationProducer_Close(t *testing.T) {
+	t.Parallel()
+	testutil.Integration(t)
+
+	topicAndGroup := testutil.Random(t)
+	options := kafkaclient.TestProducerConfig(t, topicAndGroup)
+
+	producer, err := kafkaclient.NewProducer(options...)
+	require.NoError(t, err)
+
+	ch := make(chan error)
+	go func() {
+		ch <- producer.Close() // Close is working as expected, and the producer is terminated.
+		ch <- producer.Close() // Close should return nil immediately, due to `sync.Once`.
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+			t.Fatal("timeout while waiting for close to finish")
+		}
+	}
+}
+
+func TestIntegrationProducer_Close_WithoutInterrupt(t *testing.T) {
+	t.Parallel()
+	testutil.Integration(t)
+
+	topic := testutil.Random(t)
+	options := kafkaclient.TestProducerConfig(t, topic, streamconfig.ManualInterruptHandling())
+
+	producer, err := kafkaclient.NewProducer(options...)
+	require.NoError(t, err)
+
+	ch := make(chan error)
+	go func() {
+		ch <- producer.Close() // Close is working as expected, and the producer is terminated.
+		ch <- producer.Close() // Close should return nil immediately, due to `sync.Once`.
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+			t.Fatal("timeout while waiting for close to finish")
+		}
+	}
+}
+
 func TestIntegrationProducer_Messages(t *testing.T) {
 	t.Parallel()
 	testutil.Integration(t)

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -3,10 +3,8 @@ package kafkaclient_test
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/blendle/go-streamprocessor/stream"
-	"github.com/blendle/go-streamprocessor/streamclient"
 	"github.com/blendle/go-streamprocessor/streamclient/kafkaclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
@@ -93,18 +91,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	require.Zero(t, producer.Flush(1000))
 	producer.Close()
 
-	consumer, err := kafkaclient.NewConsumer(
-		streamconfig.KafkaBroker(kafkaconfig.TestBrokerAddress),
-		streamconfig.KafkaTopic(topicAndGroup),
-		streamconfig.KafkaGroupID(topicAndGroup),
-	)
-	require.NoError(t, err)
-	defer func() {
-		time.Sleep(100 * time.Millisecond)
-		assert.NoError(t, consumer.Close())
-	}()
-
-	message := streamclient.TestMessageFromConsumer(t, consumer)
+	message := kafkaclient.TestMessageFromTopic(t, topicAndGroup)
 
 	assert.Equal(t, "hello world", string(message.Value))
 }

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -71,7 +71,6 @@ func NewConsumer(options ...streamconfig.Option) (stream.Consumer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if c.c.HandleInterrupt {
-		c.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(c.signals, c.Close, c.logger)
 	}
 
@@ -182,6 +181,7 @@ func newConsumer(options []streamconfig.Option) (*consumer, error) {
 		errors:   make(chan error),
 		messages: make(chan stream.Message),
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return c, nil

--- a/streamclient/standardstreamclient/producer.go
+++ b/streamclient/standardstreamclient/producer.go
@@ -67,7 +67,6 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 	// This functionality is enabled by default, but can be disabled through a
 	// configuration flag.
 	if p.c.HandleInterrupt {
-		p.signals = make(chan os.Signal, 3)
 		go streamutil.HandleInterrupts(p.signals, p.Close, p.logger)
 	}
 
@@ -149,6 +148,7 @@ func newProducer(ch chan stream.Message, options []streamconfig.Option) (*produc
 		errors:   make(chan error),
 		messages: ch,
 		once:     &sync.Once{},
+		signals:  make(chan os.Signal, 3),
 	}
 
 	return p, nil

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamclient/standardstreamclient"
 	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,6 +38,50 @@ func TestNewProducer_WithOptions(t *testing.T) {
 	defer func() { require.NoError(t, producer.Close()) }()
 
 	assert.EqualValues(t, buffer, producer.Config().(streamconfig.Producer).Standardstream.Writer)
+}
+
+func TestProducer_Close(t *testing.T) {
+	t.Parallel()
+
+	producer, err := standardstreamclient.NewProducer()
+	require.NoError(t, err)
+
+	ch := make(chan error)
+	go func() {
+		ch <- producer.Close() // Close is working as expected, and the producer is terminated.
+		ch <- producer.Close() // Close should return nil immediately, due to `sync.Once`.
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+			t.Fatal("timeout while waiting for close to finish")
+		}
+	}
+}
+
+func TestProducer_Close_WithoutInterrupt(t *testing.T) {
+	t.Parallel()
+
+	producer, err := standardstreamclient.NewProducer(streamconfig.ManualInterruptHandling())
+	require.NoError(t, err)
+
+	ch := make(chan error)
+	go func() {
+		ch <- producer.Close() // Close is working as expected, and the producer is terminated.
+		ch <- producer.Close() // Close should return nil immediately, due to `sync.Once`.
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-ch:
+			assert.NoError(t, err)
+		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+			t.Fatal("timeout while waiting for close to finish")
+		}
+	}
 }
 
 func TestProducer_Messages(t *testing.T) {

--- a/streamclient/standardstreamclient/producer_test.go
+++ b/streamclient/standardstreamclient/producer_test.go
@@ -56,7 +56,7 @@ func TestProducer_Close(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}
@@ -78,7 +78,7 @@ func TestProducer_Close_WithoutInterrupt(t *testing.T) {
 		select {
 		case err := <-ch:
 			assert.NoError(t, err)
-		case <-time.After(testutil.MultipliedDuration(t, 1*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(t, 3*time.Second)):
 			t.Fatal("timeout while waiting for close to finish")
 		}
 	}

--- a/streamconfig/config.go
+++ b/streamconfig/config.go
@@ -100,7 +100,6 @@ type Producer struct {
 
 // ConsumerDefaults holds the default values for Consumer.
 var ConsumerDefaults = Consumer{
-	Logger:          zap.NewNop(),
 	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "consumer",
@@ -109,7 +108,6 @@ var ConsumerDefaults = Consumer{
 
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
-	Logger:          zap.NewNop(),
 	HandleErrors:    true,
 	HandleInterrupt: true,
 	Name:            "producer",

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestConsumer(t *testing.T) {
@@ -24,7 +24,7 @@ func TestConsumer(t *testing.T) {
 		Kafka:           kafkaconfig.Consumer{},
 		Pubsub:          pubsubconfig.Consumer{},
 		Standardstream:  standardstreamconfig.Consumer{},
-		Logger:          zap.NewNop(),
+		Logger:          testutil.Logger(t),
 		HandleInterrupt: false,
 		Name:            "",
 		AllowEnvironmentBasedConfiguration: false,
@@ -307,7 +307,7 @@ func TestProducer(t *testing.T) {
 		Kafka:           kafkaconfig.Producer{},
 		Pubsub:          pubsubconfig.Producer{},
 		Standardstream:  standardstreamconfig.Producer{},
-		Logger:          zap.NewNop(),
+		Logger:          testutil.Logger(t),
 		HandleInterrupt: false,
 		Name:            "",
 		AllowEnvironmentBasedConfiguration: false,

--- a/streamconfig/initializers.go
+++ b/streamconfig/initializers.go
@@ -44,7 +44,15 @@ func NewConsumer(options ...Option) (Consumer, error) {
 
 	// Make sure we set a logger if it was explicitly set to nil.
 	if config.Logger == nil {
-		config.Logger = zap.NewNop()
+		cfg := zap.NewProductionConfig()
+		cfg.Level.SetLevel(zap.ErrorLevel)
+
+		log, err := cfg.Build()
+		if err != nil {
+			return *config, err
+		}
+
+		config.Logger = log
 	}
 
 	config.Logger.Info(
@@ -92,7 +100,15 @@ func NewProducer(options ...Option) (Producer, error) {
 
 	// Make sure we set a logger if it was explicitly set to nil.
 	if config.Logger == nil {
-		config.Logger = zap.NewNop()
+		cfg := zap.NewProductionConfig()
+		cfg.Level.SetLevel(zap.ErrorLevel)
+
+		log, err := cfg.Build()
+		if err != nil {
+			return *config, err
+		}
+
+		config.Logger = log
 	}
 
 	config.Logger.Info(

--- a/streamconfig/testing_test.go
+++ b/streamconfig/testing_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestTestNewConsumer(t *testing.T) {
 	c1, _ := streamconfig.NewConsumer()
+	c1.Logger = nil
+
 	c2 := streamconfig.TestNewConsumer(t, true)
+	c2.Logger = nil
 
 	assert.EqualValues(t, c1, c2)
 }
@@ -62,7 +65,10 @@ func TestTestNewConsumer_WithOptionsAndEnvironmentVariables(t *testing.T) {
 
 func TestTestNewProducer(t *testing.T) {
 	p1, _ := streamconfig.NewProducer()
+	p1.Logger = nil
+
 	p2 := streamconfig.TestNewProducer(t, true)
+	p2.Logger = nil
 
 	assert.EqualValues(t, p1, p2)
 }

--- a/streamutil/interrupt.go
+++ b/streamutil/interrupt.go
@@ -40,6 +40,8 @@ func HandleInterrupts(signals chan os.Signal, closer func() error, logger *zap.L
 
 	go func() {
 		abort := make(chan os.Signal, 1)
+		defer close(abort)
+
 		signal.Notify(abort, os.Interrupt)
 		<-abort
 

--- a/streamutil/interrupt_test.go
+++ b/streamutil/interrupt_test.go
@@ -1,8 +1,6 @@
 package streamutil_test
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blendle/go-streamprocessor/streamutil"
+	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -19,13 +18,14 @@ import (
 func TestInterrupt(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("BE_TESTING_FATAL") == "1" {
+	if os.Getenv("RUN_WITH_EXEC") == "1" {
+		println("go")
+
 		select {
 		case s := <-streamutil.Interrupt():
 			println("interrupt received:", s.String())
 			return
-		case <-time.After(6 * time.Second):
-			os.Exit(1)
+		case <-time.After(1 * time.Second):
 		}
 
 		return
@@ -39,18 +39,14 @@ func TestInterrupt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.String(), func(t *testing.T) {
-			cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
-			cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+			want := "interrupt received: " + tt.String()
 
-			var b bytes.Buffer
-			cmd.Stderr = bufio.NewWriter(&b)
-			require.NoError(t, cmd.Start())
-			time.Sleep(4 * time.Second)
+			out, err := testutil.Exec(t, "go", func(tb testing.TB, cmd *exec.Cmd) {
+				require.NoError(t, cmd.Process.Signal(tt))
+			})
 
-			require.NoError(t, cmd.Process.Signal(tt))
-			require.NoError(t, cmd.Wait())
-
-			assert.Contains(t, b.String(), "interrupt received: "+tt.String())
+			require.Nil(t, err)
+			assert.Contains(t, out, want)
 		})
 	}
 }
@@ -58,40 +54,34 @@ func TestInterrupt(t *testing.T) {
 func TestInterrupt_NoSignal(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("BE_TESTING_FATAL") == "1" {
+	if os.Getenv("RUN_WITH_EXEC") == "1" {
 		select {
 		case <-streamutil.Interrupt():
-			os.Exit(1)
-		case <-time.After(3 * time.Second):
-			println("no signal!")
-			return
+		case <-time.After(100 * time.Millisecond):
+			println("no signal")
 		}
 
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
-	cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+	out, err := testutil.Exec(t, "", nil)
 
-	var b bytes.Buffer
-	cmd.Stderr = bufio.NewWriter(&b)
-	require.NoError(t, cmd.Start())
-	time.Sleep(150 * time.Millisecond)
-	require.NoError(t, cmd.Wait())
-
-	assert.Contains(t, b.String(), "no signal!")
+	require.Nil(t, err)
+	assert.Contains(t, out, "no signal")
 }
 
 func TestHandleInterrupts(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("BE_TESTING_FATAL") == "1" {
+	if os.Getenv("RUN_WITH_EXEC") == "1" {
+		println("go")
+
 		ch := make(chan os.Signal)
 		logger, err := zap.NewDevelopment()
 		require.NoError(t, err)
 
 		fn := func() error {
-			println("closed!")
+			println("closed")
 			return nil
 		}
 
@@ -109,18 +99,12 @@ func TestHandleInterrupts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.String(), func(t *testing.T) {
-			cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
-			cmd.Env = append(os.Environ(), "BE_TESTING_FATAL=1")
+			out, err := testutil.Exec(t, "go", func(tb testing.TB, cmd *exec.Cmd) {
+				require.NoError(t, cmd.Process.Signal(tt))
+			})
 
-			var b bytes.Buffer
-			cmd.Stderr = bufio.NewWriter(&b)
-			require.NoError(t, cmd.Start())
-			time.Sleep(150 * time.Millisecond)
-
-			require.NoError(t, cmd.Process.Signal(tt))
-			require.NoError(t, cmd.Wait())
-
-			assert.Contains(t, b.String(), fmt.Sprintf(`{"signal": "%s"}`, tt.String()))
+			require.Nil(t, err)
+			assert.Contains(t, out, fmt.Sprintf(`{"signal": "%s"}`, tt.String()))
 		})
 	}
 }

--- a/streamutil/testutil/testing.go
+++ b/streamutil/testutil/testing.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 var validIntegrationTestName = regexp.MustCompile(`^(Test|Benchmark)(Integration)?.+$`)
@@ -37,6 +40,18 @@ func Integration(tb testing.TB) {
 	if testing.Short() {
 		tb.Skip("integration test skipped due to -short")
 	}
+}
+
+// Logger returns a Zap logger instance to use during testing. It returns logs
+// in a user-friendly format, reporting anything above warn level.
+func Logger(tb testing.TB) *zap.Logger {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.Level.SetLevel(zap.ErrorLevel)
+
+	log, err := cfg.Build()
+	require.NoError(tb, err)
+
+	return log
 }
 
 // Verbose returns true if the `testing.Verbose` flag returns true, or if the

--- a/streamutil/testutil/testing.go
+++ b/streamutil/testutil/testing.go
@@ -1,13 +1,16 @@
 package testutil
 
 import (
+	"bufio"
 	"fmt"
 	"math"
 	"math/rand"
 	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,10 +23,62 @@ var validRandomName = regexp.MustCompile(`[a-zA-Z0-9_]+`)
 
 // TestMultiplier can be used to increase the default duration or integers used
 // during test runs when waiting for time-sensitive values to be returned. It
-// defaults to a multiplier of 1.
+// defaults to a multiplier of 1.0.
 //
 // This is specifically useful on slower environments like a CI server.
-var TestMultiplier = "1"
+var TestMultiplier = "1.0"
+
+// Exec runs the current executed test as an external command, setting the
+// `RUN_WITH_EXEC` environment variable to `1`, waiting for the `wait` string to
+// be printed on stderr (unless empty), executes the `runner` function, and
+// returns the stderr output and the exit status of the command.
+func Exec(tb testing.TB, wait string, runner func(tb testing.TB, cmd *exec.Cmd)) (string, error) {
+	tb.Helper()
+
+	var out1, out2 []string
+	var wg sync.WaitGroup
+
+	cmd := exec.Command(os.Args[0], "-test.run="+tb.Name()) // nolint:gas
+	cmd.Env = append(os.Environ(), "RUN_WITH_EXEC=1")
+
+	stderr, err := cmd.StderrPipe()
+	require.NoError(tb, err)
+
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(tb, err)
+
+	require.NoError(tb, cmd.Start())
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			out1 = append(out1, scanner.Text())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			s := scanner.Text()
+
+			if runner != nil && wait == s {
+				time.Sleep(10 * time.Millisecond)
+				runner(tb, cmd)
+			}
+
+			out2 = append(out2, s)
+		}
+	}()
+
+	wg.Wait()
+
+	return strings.Join(append(out1, out2...), "\n"), cmd.Wait()
+}
 
 // Integration skips the test if the `-short` flag is specified. It also
 // enforces the test name to starts with `Integration`, this allows to run
@@ -61,7 +116,7 @@ func Logger(tb testing.TB) *zap.Logger {
 func Verbose(tb testing.TB) bool {
 	tb.Helper()
 
-	if testing.Verbose() {
+	if _, ok := os.LookupEnv("TEST_DEBUG"); ok {
 		return true
 	}
 
@@ -73,25 +128,26 @@ func Verbose(tb testing.TB) bool {
 func MultipliedDuration(tb testing.TB, d time.Duration) time.Duration {
 	tb.Helper()
 
-	m, err := strconv.Atoi(TestMultiplier)
+	m, err := strconv.ParseFloat(TestMultiplier, 64)
 	if err != nil {
-		tb.Fatalf("unable to convert TestMultiplier to integer: %s", TestMultiplier)
+		tb.Fatalf("unable to convert TestMultiplier to float: %s", TestMultiplier)
 	}
 
-	return time.Duration(d.Nanoseconds() * int64(m))
+	return time.Duration(float64(d.Nanoseconds()) * m)
 }
 
 // MultipliedInt returns the provided int, multiplied by the configured
-// `TestMultiplier` variable.
+// `TestMultiplier` variable. `TestMultiplier` is a float, but is converted to
+// the next logical integer (ceiling).
 func MultipliedInt(tb testing.TB, i int) int {
 	tb.Helper()
 
-	m, err := strconv.Atoi(TestMultiplier)
+	m, err := strconv.ParseFloat(TestMultiplier, 64)
 	if err != nil {
-		tb.Fatalf("unable to convert TestMultiplier to integer: %s", TestMultiplier)
+		tb.Fatalf("unable to convert TestMultiplier to float: %s", TestMultiplier)
 	}
 
-	return i * m
+	return i * int(math.Ceil(m))
 }
 
 // Random returns a random string, to use during testing.
@@ -102,4 +158,19 @@ func Random(tb testing.TB) string {
 	name := strings.Replace(tb.Name(), "/", "_", -1)
 	name = validRandomName.FindString(name)
 	return fmt.Sprintf("%s-%d", name, rand.Intn(math.MaxInt64))
+}
+
+// WithMultiplier runs the passed in function with the configured test
+// multiplier. Note that this function is NOT thread-safe. If you call this
+// function in tests that set `Parallel()`, you might get unexpected results.
+func WithMultiplier(tb testing.TB, f float64, fn func(tb testing.TB)) {
+	if fn == nil {
+		return
+	}
+
+	tm := TestMultiplier
+	defer func() { TestMultiplier = tm }()
+
+	TestMultiplier = fmt.Sprintf("%.4f", f)
+	fn(tb)
 }

--- a/streamutil/testutil/testing_test.go
+++ b/streamutil/testutil/testing_test.go
@@ -2,6 +2,7 @@ package testutil_test
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,10 @@ import (
 
 func TestIntegration_Test(t *testing.T) {
 	testutil.Integration(t)
+}
+
+func TestLogger(t *testing.T) {
+	assert.Equal(t, "*zap.Logger", reflect.TypeOf(testutil.Logger(t)).String())
 }
 
 func TestVerbose(t *testing.T) {


### PR DESCRIPTION
If `ManualInterruptHandling` was set to `true`, no signals channel was
created, which caused a panic when closing a consumer or producer.

This fixes that.