### PR TITLE
Support zero-based default offset

### DIFF
--- a/streamclient/kafkaclient/eventhandlers.go
+++ b/streamclient/kafkaclient/eventhandlers.go
@@ -19,20 +19,20 @@ func (c *consumer) handleAssignedPartitions(e kafka.AssignedPartitions) {
 		tps[i] = e.Partitions[i]
 	}
 
-	// If OffsetDefault is set to anything other than zero, this consumer is
+	// If OffsetDefault is set to anything other than nil, this consumer is
 	// configured to receive data from a either a positive (starting from the
 	// beginning), or negative offset (starting from the end). In this case, we
 	// manually override the starting offset of the partition when we receive an
 	// assigned partition request, but only if no offset is stored yet at the
 	// Kafka brokers.
-	if c.c.Kafka.OffsetDefault != 0 {
+	if c.c.Kafka.OffsetDefault != nil {
 		// Set offsets, to support custom initial offsets. We start by setting the
 		// offset as usual, then we convert the offset to a "tail" type if we're
 		// actually dealing with a negative integer.
 		//
 		// see: https://git.io/vpa3B
-		offset := kafka.Offset(c.c.Kafka.OffsetDefault)
-		if c.c.Kafka.OffsetDefault < 0 {
+		offset := kafka.Offset(*c.c.Kafka.OffsetDefault)
+		if *c.c.Kafka.OffsetDefault < 0 {
 			offset = kafka.OffsetTail(-offset)
 		}
 

--- a/streamconfig/config_test.go
+++ b/streamconfig/config_test.go
@@ -133,14 +133,14 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 		"Kafka.OffsetDefault (positive)": {
 			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "10"},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: 10},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{10}[0]},
 			},
 		},
 
 		"Kafka.OffsetDefault (negative)": {
 			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "-10"},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: -10},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{-10}[0]},
 			},
 		},
 

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -72,7 +72,7 @@ type Consumer struct {
 	// If you want to make sure that the provided offset is _always_ used as a
 	// starting point, you can use this value in conjunction with
 	// `streamconfig.GroupIDRandom()`.
-	OffsetDefault int64 `kafka:"-" split_words:"true"`
+	OffsetDefault *int64 `kafka:"-" split_words:"true"`
 
 	// OffsetInitial dictates what to do when there is no initial offset in Kafka
 	// or if the current offset does not exist any more on the server (e.g.

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -31,7 +31,7 @@ func TestConsumer(t *testing.T) {
 		ID:                  "",
 		MaxInFlightRequests: 0,
 		OffsetInitial:       kafkaconfig.OffsetBeginning,
-		OffsetDefault:       5,
+		OffsetDefault:       &[]int64{5}[0],
 		SecurityProtocol:    kafkaconfig.ProtocolPlaintext,
 		SessionTimeout:      time.Duration(0),
 		SSL:                 kafkaconfig.SSL{KeyPath: ""},
@@ -146,7 +146,7 @@ func TestConsumer_ConfigMap(t *testing.T) {
 		},
 
 		"offsetDefault": {
-			&kafkaconfig.Consumer{OffsetDefault: 12},
+			&kafkaconfig.Consumer{OffsetDefault: &[]int64{12}[0]},
 			&kafka.ConfigMap{},
 		},
 

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -252,7 +252,9 @@ func KafkaMaxQueueSizeMessages(i int) Option {
 // This option has no effect when applied to a producer.
 func KafkaOffsetHead(i uint32) Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
-		c.Kafka.OffsetDefault = int64(i)
+		i64 := int64(i)
+
+		c.Kafka.OffsetDefault = &i64
 	})
 }
 
@@ -270,7 +272,9 @@ func KafkaOffsetInitial(s kafkaconfig.Offset) Option {
 // This option has no effect when applied to a producer.
 func KafkaOffsetTail(i uint32) Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
-		c.Kafka.OffsetDefault = -int64(i)
+		i64 := -int64(i)
+
+		c.Kafka.OffsetDefault = &i64
 	})
 }
 

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -249,7 +249,7 @@ func TestOptions(t *testing.T) {
 		"KafkaOffsetHead": {
 			[]streamconfig.Option{streamconfig.KafkaOffsetHead(10)},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: 10},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{10}[0]},
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},
@@ -259,7 +259,7 @@ func TestOptions(t *testing.T) {
 		"KafkaOffsetHead (MaxUint32)": {
 			[]streamconfig.Option{streamconfig.KafkaOffsetHead(math.MaxUint32)},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: int64(math.MaxUint32)},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{int64(math.MaxUint32)}[0]},
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},
@@ -279,7 +279,7 @@ func TestOptions(t *testing.T) {
 		"KafkaOffsetTail": {
 			[]streamconfig.Option{streamconfig.KafkaOffsetTail(10)},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: -10},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{-10}[0]},
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},
@@ -289,7 +289,7 @@ func TestOptions(t *testing.T) {
 		"KafkaOffsetTail (MaxUint32)": {
 			[]streamconfig.Option{streamconfig.KafkaOffsetTail(math.MaxUint32)},
 			streamconfig.Consumer{
-				Kafka: kafkaconfig.Consumer{OffsetDefault: -int64(math.MaxUint32)},
+				Kafka: kafkaconfig.Consumer{OffsetDefault: &[]int64{-int64(math.MaxUint32)}[0]},
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},


### PR DESCRIPTION
This is a follow-up to https://github.com/blendle/go-streamprocessor/pull/73.

---

Since offsets are zero-based, setting the default offset to 0 is a
valid use-case.

This change makes OffsetDefault a pointer to an int64 value, making it
possible to distinguish between a `0` offset, and an unset (`nil`)
offset.

The convenience options `KafkaOffsetHead` and `KafkaOffsetTail` still
work the same as before, accepting an int32 value.