### PR TITLE
Swap KafkaGroupIDRandom from rand int64 to uuidV4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,6 +31,11 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -67,6 +72,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "801e40ab920072c4f68eb4edc3606ed63a9814cfd8976071d7fa6f7f05f54701"
+  inputs-digest = "34741af07423203751781915ff968cdf26e02e421eef05a5896a944a257800ce"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,3 +9,7 @@
 [[constraint]]
   name = "github.com/kelseyhightower/envconfig"
   revision = "1f94cfab3dcc47159a6dcb83588baa3d8260e78a"
+
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -3,8 +3,6 @@ package streamconfig
 import (
 	"fmt"
 	"io"
-	"math"
-	"math/rand"
 	"time"
 
 	"github.com/blendle/go-streamprocessor/stream"
@@ -12,6 +10,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
 
@@ -175,14 +174,9 @@ func KafkaGroupID(s string) Option {
 // number generator. For true randomness, pass in `time.Now().Unix()`.
 //
 // This option has no effect when applied to a producer.
-func KafkaGroupIDRandom(i int64) Option {
+func KafkaGroupIDRandom() Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
-		// Note: we should probably not do this globally.
-		//
-		// see: https://nishanths.svbtle.com/do-not-seed-the-global-random
-		rand.Seed(i)
-
-		c.Kafka.GroupID = fmt.Sprintf("processor-%d", rand.Intn(math.MaxInt64))
+		c.Kafka.GroupID = fmt.Sprintf("processor-%s", uuid.Must(uuid.NewV4()))
 	})
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/blendle/go-streamprocessor/pull/74.

---

Before, `streamconfig.KafkaGroupIDRandom()` would generate a random
group ID based on a random int64 value. It required you to pass in a
seed value to make sure the returned ID was _actually_ random.

Now, no argument is required, and instead the group ID is now based on a
generated UUID V4 string.

There are several reasons for this change:

- the interface is easier (no more arguments required)
- it is in-line with how `kafkacat` handles random group IDs
- it increases the randomness, reducing group ID collisions