### PR TITLE
Correctly set Kafka's default producer security protocol

### DIFF
--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -54,6 +54,7 @@ func TestConsumerDefaults(t *testing.T) {
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, kafkaconfig.OffsetBeginning, config.OffsetInitial)
+	assert.Equal(t, kafkaconfig.ProtocolPlaintext, config.SecurityProtocol)
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
 	assert.Equal(t, 15*time.Minute, config.StatisticsInterval)

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -142,6 +142,7 @@ var ProducerDefaults = Producer{
 	MaxQueueSizeKBytes:     2097151,
 	MaxQueueSizeMessages:   1000000,
 	RequiredAcks:           AckLeader,
+	SecurityProtocol:       ProtocolPlaintext,
 	SessionTimeout:         30 * time.Second,
 	SSL:                    SSL{},
 	StatisticsInterval:     15 * time.Minute,

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -60,6 +60,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)
 	assert.Equal(t, 1000000, config.MaxQueueSizeMessages)
 	assert.EqualValues(t, kafkaconfig.AckLeader, config.RequiredAcks)
+	assert.Equal(t, kafkaconfig.ProtocolPlaintext, config.SecurityProtocol)
 	assert.Equal(t, 30*time.Second, config.SessionTimeout)
 	assert.Equal(t, kafkaconfig.SSL{}, config.SSL)
 	assert.Equal(t, 15*time.Minute, config.StatisticsInterval)


### PR DESCRIPTION
This was already set for the consumer, but not the producer.