### PR TITLE
Tweak consumer configuration

### DIFF
--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -166,6 +166,19 @@ type staticConsumer struct {
 	// Unassign() respectively. This is set to `true`, since we handle these
 	// events ourselves.
 	EnableEventRebalance bool `kafka:"go.application.rebalance.enable"`
+
+	// QueuedMinMessages dictates the minimum number of messages per
+	// topic+partition librdkafka tries to maintain in the local consumer queue.
+	//
+	// See: https://git.io/vp5eH
+	QueuedMinMessages int `kafka:"queued.min.messages"`
+
+	// SocketBlockingMax dictates the maximum time a broker socket operation may
+	// block. A lower value improves responsiveness at the expense of slightly
+	// higher CPU usage.
+	//
+	// See: https://git.io/vp5eH
+	SocketBlockingMax time.Duration `kafka:"socket.blocking.max.ms"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.
@@ -187,6 +200,8 @@ var staticConsumerDefaults = &staticConsumer{
 	EnableAutoCommit:        true,
 	EnableAutoOffsetStore:   false,
 	EnableEventRebalance:    true,
+	QueuedMinMessages:       500000,
+	SocketBlockingMax:       50 * time.Millisecond,
 }
 
 // ConfigMap converts the current configuration into a format known to the

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -17,6 +17,8 @@ var consumerDefaults = map[string]interface{}{
 	"enable.auto.commit":              true,
 	"enable.auto.offset.store":        false,
 	"go.application.rebalance.enable": true,
+	"queued.min.messages":             500000,
+	"socket.blocking.max.ms":          50,
 }
 
 var consumerOmitempties = []string{


### PR DESCRIPTION
To improve performance of fast processors, and improve equality when
consuming from multiple partitions.