### PR TITLE
Add initial support for printing processor usage

### DIFF
--- a/streamutil/usage.go
+++ b/streamutil/usage.go
@@ -1,0 +1,226 @@
+package streamutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/blendle/go-streamprocessor/streamconfig"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// About provides details about the processor and its configuration.
+type About struct {
+	Name,
+	URI,
+	Usage string
+
+	Consumers,
+	Producers []string
+
+	Config map[string]string
+}
+
+type name struct {
+	Upper, Lower, Usage, Line string
+}
+
+type usageData struct {
+	Name,
+	NameLine,
+	Usage,
+	URI string
+
+	Consumers,
+	Producers []name
+
+	Config map[string][]string
+
+	Count int
+}
+
+// TODO:
+// - split up into multiple templates
+// - colorize headers
+// - colorize environment variables
+// - properly split lines at 80 characters
+// - indent anything other than headers by 2 spaces
+// - underline documentation link
+// - add configurable "EXAMPLE" header at the top
+// - improve consumer/producer environment variable output
+//   - show default values
+//   - show descriptions
+//   - show required true/false
+//   - use same format as "PROCESSOR CONFIGURATION"
+const usage = `
+{{ .Name }}
+{{ .NameLine }}
+
+{{ .Usage }}
+
+{{ if .URI }}
+🐚 ONLINE DOCUMENTATION
+-----------------------
+
+For more details about this processor, see the following URL:
+
+    {{ .URI }}
+{{ end }}
+{{ if .Count }}
+🐝 USAGE
+--------
+
+This stream processor is configured via environment variables. The list of
+available variables is split between these {{ .Count }} sections:
+
+{{ if .Config -}}
+* PROCESSOR CONFIGURATION – how to configure the business logic of this
+  processor via environment variables.
+{{ end }}
+
+{{- range .Consumers }}
+* {{ .Upper }} – how to configure the {{if eq .Lower "consumer"}}default {{end}}{{.Lower}}
+{{ end }}
+
+{{- range .Producers }}
+* {{ .Upper }} – how to configure the {{if eq .Lower "producer"}}default {{end}}{{.Lower}}
+{{ end }}
+
+{{ if .Config -}}
+⚙️  PROCESSOR CONFIGURATION
+--------------------------
+{{ range $k, $v := .Config }}
+{{ $k }}
+{{- range $v }}
+    {{ . }}
+{{- end }}
+{{ end }}
+{{ end }}
+{{- range .Consumers }}
+⚙️  {{ .Upper }}
+---{{ .Line }}
+
+In order to use this consumer, you need to set the environment variable
+"STREAMCLIENT_CONSUMER" to one of the following values:
+
+* standardstream
+* inmem
+* kafka
+* pubsub
+
+Alternatively, if you pipe any input to this consumer over stdin, and don't set
+the "STREAMCLIENT_CONSUMER" environment variable, the consumer mode will be set
+to "standardstream".
+
+In any other situation, the consumer will terminate.
+
+{{ .Usage }}
+{{ end }}
+{{- range .Producers }}
+⚙️  {{ .Upper }}
+---{{ .Line }}
+
+In order to use this producer, you need to set the environment variable
+"STREAMCLIENT_PRODUCER" to one of the following values:
+
+* standardstream
+* inmem
+* kafka
+* pubsub
+
+Alternatively, if you set the environment variable "DRY_RUN" to any value, and
+don't set the "STREAMCLIENT_PRODUCER" environment variable, the producer mode
+will be set to "standardstream".
+
+In any other situation, the producer will terminate.
+
+{{ .Usage }}
+{{ end }}
+{{ end }}
+`
+
+// Usage listens for `--help` and prints the relevant details on how to use the
+// processor. A boolean is returned indicating if the usage documentation is
+// printed, at which point the processor should probably exit.
+func Usage(out io.Writer, about About) bool {
+	if len(os.Args) < 2 {
+		return false
+	}
+
+	if os.Args[1] != "--help" && os.Args[1] != "-h" {
+		return false
+	}
+
+	count := len(about.Consumers) + len(about.Producers)
+	if len(about.Config) > 0 {
+		count++
+	}
+
+	var consumers []name
+	for _, c := range about.Consumers {
+		b := &bytes.Buffer{}
+		tabs := tabwriter.NewWriter(b, 1, 0, 4, ' ', 0)
+		conf := &streamconfig.Consumer{}
+
+		_ = envconfig.Usagef(c, conf, tabs, envconfig.DefaultTableFormat) // nolint:gas
+		_ = tabs.Flush()                                                  // nolint:gas
+
+		cc := strings.Replace(c, "_", " ", -1)
+		consumers = append(consumers, name{
+			Lower: cc,
+			Upper: strings.ToUpper(cc),
+			Usage: b.String(),
+			Line:  strings.Repeat("-", len(cc)),
+		})
+	}
+
+	var producers []name
+	for _, p := range about.Producers {
+		b := &bytes.Buffer{}
+		tabs := tabwriter.NewWriter(b, 1, 0, 4, ' ', 0)
+		conf := &streamconfig.Producer{}
+
+		_ = envconfig.Usagef(p, conf, tabs, envconfig.DefaultTableFormat) // nolint:gas
+		_ = tabs.Flush()                                                  // nolint:gas
+
+		pp := strings.Replace(p, "_", " ", -1)
+		producers = append(producers, name{
+			Lower: pp,
+			Upper: strings.ToUpper(pp),
+			Usage: b.String(),
+			Line:  strings.Repeat("-", len(pp)),
+		})
+	}
+
+	config := map[string][]string{}
+	for k, v := range about.Config {
+		config[k] = strings.Split(v, "\n")
+	}
+
+	data := &usageData{
+		Name:      about.Name,
+		NameLine:  strings.Repeat("=", len(about.Name)),
+		Usage:     about.Usage,
+		URI:       about.URI,
+		Consumers: consumers,
+		Producers: producers,
+		Config:    config,
+		Count:     count,
+	}
+
+	t := template.Must(template.New("usage").Parse(usage))
+	buf := &bytes.Buffer{}
+	if err := t.Execute(buf, data); err != nil {
+		panic(err)
+	}
+
+	_, err := out.Write(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	return true
+}


### PR DESCRIPTION
This was triggered by @niels-s trying to use one of the processors, using `--help` and expecting to see how the processor works.

While all processors have their own README, they don't (always) cover the exact usage/configuration of the consumers/producers.

This is an initial (pretty crappy) version. But I wanted to have _something_ for now.

See https://github.com/blendle/go-streamprocessor/issues/85 for future plans.

---

A processor would use this at the top of the `main` function as follows:

```golang
about := streamutil.About{
  Name:      "Stream Processor: Hello World",
  URI:       "https://my-link-to-docs",
  Usage:     "Brief description about this processor.",
  Config:    map[string]string{
    "MY_CONFIG_ENV_VAR": "env var description here...",
    "MY_OTHER_ENV_VAR": "another description here...",
  },
  Consumers: []string{"consumer"},
  Producers: []string{"producer", "my_other_producer"},
}

if streamutil.Usage(os.Stderr, about) {
  os.Exit(0)
}
```

Then, when passing either `--help` or `-h` to the processor, the
following response would be printed to stderr:

    Stream Processor: Hello World
    =============================

    Brief description about this processor.


    🐚 ONLINE DOCUMENTATION
    -----------------------

    For more details about this processor, see the following URL:

        https://my-link-to-docs


    🐝 USAGE
    --------

    This stream processor is configured via environment variables. The list of
    available variables is split between these 4 sections:

    * PROCESSOR CONFIGURATION – how to configure the business logic of this
      processor via environment variables.

    * CONSUMER – how to configure the default consumer

    * PRODUCER – how to configure the default producer

    * MY OTHER PRODUCER – how to configure the my other producer


    ⚙️  PROCESSOR CONFIGURATION
    --------------------------

    MY_CONFIG_ENV_VAR
        env var description here...

    MY_OTHER_ENV_VAR
        another description here...


    ⚙️  CONSUMER
    -----------

    In order to use this consumer, you need to set the environment variable
    "STREAMCLIENT_CONSUMER" to one of the following values:

    * standardstream
    * inmem
    * kafka
    * pubsub

    Alternatively, if you pipe any input to this consumer over stdin, and don't set
    the "STREAMCLIENT_CONSUMER" environment variable, the consumer mode will be set
    to "standardstream".

    In any other situation, the consumer will terminate.

    This application is configured via the environment. The following environment
    variables can be used:

    KEY                                      TYPE                              DEFAULT    REQUIRED    DESCRIPTION
    CONSUMER_INMEM_CONSUMEONCE               True or False
    CONSUMER_KAFKA_BROKERS                   Comma-separated list of String
    CONSUMER_KAFKA_COMMIT_INTERVAL           Duration
    CONSUMER_KAFKA_DEBUG                     Debug
    CONSUMER_KAFKA_GROUP_ID                  String
    CONSUMER_KAFKA_HEARTBEAT_INTERVAL        Duration
    CONSUMER_KAFKA_CLIENT_ID                 String
    CONSUMER_KAFKA_MAX_IN_FLIGHT_REQUESTS    Integer
    CONSUMER_KAFKA_OFFSET_DEFAULT            Integer
    CONSUMER_KAFKA_OFFSET_INITIAL            Offset
    CONSUMER_KAFKA_SECURITY_PROTOCOL         Protocol
    CONSUMER_KAFKA_SESSION_TIMEOUT           Duration
    CONSUMER_KAFKA_SSL_CA_PATH               String
    CONSUMER_KAFKA_SSL_CERT_PATH             String
    CONSUMER_KAFKA_SSL_CRL_PATH              String
    CONSUMER_KAFKA_SSL_KEY_PASSWORD          String
    CONSUMER_KAFKA_SSL_KEY_PATH              String
    CONSUMER_KAFKA_SSL_KEYSTORE_PASSWORD     String
    CONSUMER_KAFKA_SSL_KEYSTORE_PATH         String
    CONSUMER_KAFKA_STATISTICS_INTERVAL       Duration
    CONSUMER_KAFKA_TOPICS                    Comma-separated list of String


    ⚙️  PRODUCER
    -----------

    In order to use this producer, you need to set the environment variable
    "STREAMCLIENT_PRODUCER" to one of the following values:

    * standardstream
    * inmem
    * kafka
    * pubsub

    Alternatively, if you set the environment variable "DRY_RUN" to any value, and
    don't set the "STREAMCLIENT_PRODUCER" environment variable, the producer mode
    will be set to "standardstream".

    In any other situation, the producer will terminate.

    This application is configured via the environment. The following environment
    variables can be used:

    KEY                                         TYPE                              DEFAULT    REQUIRED    DESCRIPTION
    PRODUCER_KAFKA_BATCH_MESSAGE_SIZE           Integer
    PRODUCER_KAFKA_BROKERS                      Comma-separated list of String
    PRODUCER_KAFKA_COMPRESSION_CODEC            Compression
    PRODUCER_KAFKA_DEBUG                        Debug
    PRODUCER_KAFKA_HEARTBEAT_INTERVAL           Duration
    PRODUCER_KAFKA_CLIENT_ID                    String
    PRODUCER_KAFKA_MAX_DELIVERY_RETRIES         Integer
    PRODUCER_KAFKA_MAX_IN_FLIGHT_REQUESTS       Integer
    PRODUCER_KAFKA_MAX_QUEUE_BUFFER_DURATION    Duration
    PRODUCER_KAFKA_MAX_QUEUE_SIZE_KBYTES        Integer
    PRODUCER_KAFKA_MAX_QUEUE_SIZE_MESSAGES      Integer
    PRODUCER_KAFKA_REQUIRED_ACKS                Ack
    PRODUCER_KAFKA_SECURITY_PROTOCOL            Protocol
    PRODUCER_KAFKA_SESSION_TIMEOUT              Duration
    PRODUCER_KAFKA_SSL_CA_PATH                  String
    PRODUCER_KAFKA_SSL_CERT_PATH                String
    PRODUCER_KAFKA_SSL_CRL_PATH                 String
    PRODUCER_KAFKA_SSL_KEY_PASSWORD             String
    PRODUCER_KAFKA_SSL_KEY_PATH                 String
    PRODUCER_KAFKA_SSL_KEYSTORE_PASSWORD        String
    PRODUCER_KAFKA_SSL_KEYSTORE_PATH            String
    PRODUCER_KAFKA_STATISTICS_INTERVAL          Duration
    PRODUCER_KAFKA_TOPIC                        String
    PRODUCER_STANDARDSTREAM_WRITER              Writer


    ⚙️  MY OTHER PRODUCER
    --------------------

    In order to use this producer, you need to set the environment variable
    "STREAMCLIENT_PRODUCER" to one of the following values:

    * standardstream
    * inmem
    * kafka
    * pubsub

    Alternatively, if you set the environment variable "DRY_RUN" to any value, and
    don't set the "STREAMCLIENT_PRODUCER" environment variable, the producer mode
    will be set to "standardstream".

    In any other situation, the producer will terminate.

    This application is configured via the environment. The following environment
    variables can be used:

    KEY                                                  TYPE                              DEFAULT    REQUIRED    DESCRIPTION
    MY_OTHER_PRODUCER_KAFKA_BATCH_MESSAGE_SIZE           Integer
    MY_OTHER_PRODUCER_KAFKA_BROKERS                      Comma-separated list of String
    MY_OTHER_PRODUCER_KAFKA_COMPRESSION_CODEC            Compression
    MY_OTHER_PRODUCER_KAFKA_DEBUG                        Debug
    MY_OTHER_PRODUCER_KAFKA_HEARTBEAT_INTERVAL           Duration
    MY_OTHER_PRODUCER_KAFKA_CLIENT_ID                    String
    MY_OTHER_PRODUCER_KAFKA_MAX_DELIVERY_RETRIES         Integer
    MY_OTHER_PRODUCER_KAFKA_MAX_IN_FLIGHT_REQUESTS       Integer
    MY_OTHER_PRODUCER_KAFKA_MAX_QUEUE_BUFFER_DURATION    Duration
    MY_OTHER_PRODUCER_KAFKA_MAX_QUEUE_SIZE_KBYTES        Integer
    MY_OTHER_PRODUCER_KAFKA_MAX_QUEUE_SIZE_MESSAGES      Integer
    MY_OTHER_PRODUCER_KAFKA_REQUIRED_ACKS                Ack
    MY_OTHER_PRODUCER_KAFKA_SECURITY_PROTOCOL            Protocol
    MY_OTHER_PRODUCER_KAFKA_SESSION_TIMEOUT              Duration
    MY_OTHER_PRODUCER_KAFKA_SSL_CA_PATH                  String
    MY_OTHER_PRODUCER_KAFKA_SSL_CERT_PATH                String
    MY_OTHER_PRODUCER_KAFKA_SSL_CRL_PATH                 String
    MY_OTHER_PRODUCER_KAFKA_SSL_KEY_PASSWORD             String
    MY_OTHER_PRODUCER_KAFKA_SSL_KEY_PATH                 String
    MY_OTHER_PRODUCER_KAFKA_SSL_KEYSTORE_PASSWORD        String
    MY_OTHER_PRODUCER_KAFKA_SSL_KEYSTORE_PATH            String
    MY_OTHER_PRODUCER_KAFKA_STATISTICS_INTERVAL          Duration
    MY_OTHER_PRODUCER_KAFKA_TOPIC                        String
    MY_OTHER_PRODUCER_STANDARDSTREAM_WRITER              Writer