### PR TITLE
Add convenience function to handle stream errors

### DIFF
--- a/stream/common.go
+++ b/stream/common.go
@@ -1,0 +1,20 @@
+package stream
+
+// ErrorCloser interface contains a shared subset of methods between consumers
+// and producers. This subset can be used to collectively listen to errors from
+// any of the configured stream consumers or producers, and close them all when
+// one triggers an error.
+type ErrorCloser interface {
+	// Errors is a read-only channel on which the consumer or producer delivers
+	// any errors that occurred while consuming from, or producing to the stream.
+	Errors() <-chan error
+
+	// Close closes the consumer or producer. After calling this method, the
+	// consumer or producer is no longer in a usable state, and future method
+	// calls can result in panics.
+	//
+	// Check the specific implementations to know what happens when calling close,
+	// but in general any active connection to the message stream is terminated
+	// and the messages channel is closed.
+	Close() error
+}

--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -2,15 +2,13 @@ package stream
 
 // Consumer interface to be implemented by different stream clients.
 type Consumer interface {
+	ErrorCloser
+
 	// Messages is a read-only channel on which the consumer delivers any messages
 	// being read from the stream.
 	//
 	// The channel returns each message as a `stream.Message` value object.
 	Messages() <-chan Message
-
-	// Errors is a read-only channel on which the consumer delivers any errors
-	// that occurred while consuming from the stream.
-	Errors() <-chan error
 
 	// Ack can be used to acknowledge that a message was processed and should not
 	// be delivered again.
@@ -19,15 +17,6 @@ type Consumer interface {
 	// Nack is the opposite of `Ack`. It can be used to indicate that a message
 	// was _not_ processed, and should be delivered again in the future.
 	Nack(Message) error
-
-	// Close closes the consumer. After calling this method, the consumer is no
-	// longer in a usable state, and subsequent method calls can result in
-	// panics.
-	//
-	// Check the specific implementations to know what exactly happens when
-	// calling close, but in general any active connection to the message stream
-	// is terminated and the messages channel is closed.
-	Close() error
 
 	// Config returns the final configuration used by the consumer as an
 	// interface. To access the configuration, cast the interface to a

--- a/stream/producer.go
+++ b/stream/producer.go
@@ -2,24 +2,13 @@ package stream
 
 // Producer interface to be implemented by different stream clients.
 type Producer interface {
+	ErrorCloser
+
 	// Messages is a write-only channel on which you can deliver any messages that
 	// need to be produced on the message stream.
 	//
 	// The channel accepts `stream.Message` value objects.
 	Messages() chan<- Message
-
-	// Errors is a read-only channel on which the producer delivers any errors
-	// that occurred while producing to the stream.
-	Errors() <-chan error
-
-	// Close closes the producer. After calling this method, the producer is no
-	// longer in a usable state, and subsequent method calls can result in
-	// panics.
-	//
-	// Check the specific implementations to know what exactly happens when
-	// calling close, but in general no new messages will be delivered to the
-	// message stream and the messages channel is closed.
-	Close() error
 
 	// Config returns the final configuration used by the producer as an
 	// interface. To access the configuration, cast the interface to a


### PR DESCRIPTION
I came to the realization that the current error handling is flawed in a
sense that we use the provided Zap logger's `Fatal` method to log the
error.

This method then calls `os.Exit(1)`, see also: https://git.io/vhf3n.

The problem with this is that `os.Exit` does _not_ allow any deferred
functions to be executed, as it exits immediately, this unlike `panic`,
which _does_ allow the stack to complete before terminating.

But even if we switch to using `panic` instead, it would still not be
enough, because we could only handle a correct termination of the
_current_ consumer or producer, but if a processor uses multiple
consumers and/or producers, the others would still terminate without
properly cleaning up.

Cleaning up is especially important in the case of a Kafka client, since
it heavily uses internal caches of messages either to be consumer by the
client, or to be produced to the broker. If a producer for example
terminates without draining its queue, it could result in already
acknowledged messages by the consumer not being delivered by the
producer.

To solve this, I think two changes are required:

1. make it easy to handle errors from multiple consumers and/or
   producers by the processor itself, without adding too much overhead.

2. either make manual error handling the default, _or_ make it
   explicitly clear that the default isn't as fault tolerant as the
   manual solution is.