### PR TITLE
Add helper function to marshal messages in Zap log entries

### DIFF
--- a/streamlog/logger.go
+++ b/streamlog/logger.go
@@ -22,7 +22,7 @@ type tags map[string][]byte
 // For simplicity and consistency, the field key cannot be changed. It will
 // always be set to `streamMessage`. If you want to change this field, you can
 // implement your own marshaller.
-func Message(m stream.Message) zap.Field {
+func Message(m stream.Message) zapcore.Field {
 	return zap.Object("streamMessage", msg(m))
 }
 

--- a/streamlog/logger.go
+++ b/streamlog/logger.go
@@ -1,0 +1,58 @@
+package streamlog
+
+import (
+	"github.com/blendle/go-streamprocessor/stream"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// msg is an internal representation of a `stream.Message`, used to support
+// object marshalling to `zap.Field`..
+type msg stream.Message
+
+// tags is an internal representation of a set of `stream.Message` tags, used to
+// support object marshalling.
+type tags map[string][]byte
+
+// Message returns a `zap.Field` object. It is a convenience method that allows
+// you to easily add message contents to any log entries you create using Zap:
+//
+//     logger.Error(":boom:", streamlog.Message(msg))
+//
+// For simplicity and consistency, the field key cannot be changed. It will
+// always be set to `streamMessage`. If you want to change this field, you can
+// implement your own marshaller.
+func Message(m stream.Message) zap.Field {
+	return zap.Object("streamMessage", msg(m))
+}
+
+// MarshalLogObject implements Zap's `zapcore.ObjectMarshaler` interface. This
+// implementation is not put on the original `stream.Message` object, to keep
+// the API surface area of that object as small as possible.
+func (m msg) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddByteString("key", m.Key)
+	enc.AddByteString("value", m.Value)
+	enc.AddTime("timestamp", m.Timestamp)
+	enc.AddString("consumerTopic", m.ConsumerTopic)
+	enc.AddString("producerTopic", m.ProducerTopic)
+
+	if m.Offset != nil {
+		enc.AddInt64("offset", *m.Offset)
+	}
+
+	if err := enc.AddObject("tags", tags(m.Tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalLogObject adds support for marshalling a set of tags to their proper
+// Zap log message structure.
+func (t tags) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	for k, v := range t {
+		enc.AddByteString(k, v)
+	}
+
+	return nil
+}

--- a/streamlog/logger_test.go
+++ b/streamlog/logger_test.go
@@ -1,0 +1,45 @@
+package streamlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blendle/go-streamprocessor/stream"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestMessage(t *testing.T) {
+	t.Parallel()
+
+	m := stream.TestMessage(t, "key", "value")
+
+	field := Message(m)
+
+	assert.Equal(t, zap.Object("streamMessage", msg(m)), field)
+}
+
+func TestMessage_MarshalLogObject(t *testing.T) {
+	t.Parallel()
+
+	enc := zapcore.NewMapObjectEncoder()
+
+	m := msg(stream.TestMessage(t, "key", "value"))
+
+	err := m.MarshalLogObject(enc)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(m.Key), enc.Fields["key"])
+	assert.Equal(t, string(m.Value), enc.Fields["value"])
+	assert.Equal(t, m.Timestamp, enc.Fields["timestamp"])
+	assert.Equal(t, m.ConsumerTopic, enc.Fields["consumerTopic"])
+	assert.Equal(t, m.ProducerTopic, enc.Fields["producerTopic"])
+	assert.Equal(t, *m.Offset, enc.Fields["offset"])
+
+	require.Len(t, enc.Fields["tags"], len(m.Tags))
+	for k, v := range m.Tags {
+		assert.Equal(t, string(v), enc.Fields["tags"].(map[string]interface{})[k].(string))
+	}
+}


### PR DESCRIPTION
This change adds the `streamlog` package. It currently exposes a single
function:

    func Message(m stream.Message) zap.Field

You pass in a `stream.Message`, and a `zap.Field` is returned, that can
be directly passed into a Zap log entry:

    logger.Info("My message details.", streamlog.Message(msg))

For simplicity and consistency, the field key cannot be changed. It
will be set to `streamMessage`. If you want to change this field, you
can implement your own marshaller.