### PR TITLE
Allow using multiple streamclient types concurrently

### DIFF
--- a/streamclient/consumer_test.go
+++ b/streamclient/consumer_test.go
@@ -54,8 +54,8 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.env, func(t *testing.T) {
-			_ = os.Setenv("STREAMCLIENT_CONSUMER", tt.env)
-			defer os.Unsetenv("STREAMCLIENT_CONSUMER") // nolint: errcheck
+			_ = os.Setenv("CONSUMER_CLIENT_TYPE", tt.env)
+			defer os.Unsetenv("CONSUMER_CLIENT_TYPE") // nolint: errcheck
 
 			consumer, err := streamclient.NewConsumer(tt.opts)
 			require.NoError(t, err)
@@ -65,9 +65,9 @@ func TestIntegrationNewConsumer_Env(t *testing.T) {
 	}
 }
 
-func TestNewConsumer_Pubsub(t *testing.T) {
-	_ = os.Setenv("STREAMCLIENT_CONSUMER", "pubsub")
-	defer os.Unsetenv("STREAMCLIENT_CONSUMER") // nolint: errcheck
+func TestNewConsumer_Unknown(t *testing.T) {
+	_ = os.Setenv("CONSUMER_CLIENT_TYPE", "pubsub")
+	defer os.Unsetenv("CONSUMER_CLIENT_TYPE") // nolint: errcheck
 
 	_, err := streamclient.NewConsumer()
 	assert.Error(t, err)
@@ -96,9 +96,4 @@ func TestNewConsumer_PipedData(t *testing.T) {
 	if e, ok := err.(*exec.ExitError); ok {
 		assert.True(t, e.Success(), fmt.Sprintf("%s\n\n%s", e.String(), string(b)))
 	}
-}
-
-func TestNewConsumer_Unknown(t *testing.T) {
-	_, err := streamclient.NewConsumer()
-	assert.Error(t, err)
 }

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -50,8 +50,8 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.env, func(t *testing.T) {
-			_ = os.Setenv("STREAMCLIENT_PRODUCER", tt.env)
-			defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
+			_ = os.Setenv("PRODUCER_CLIENT_TYPE", tt.env)
+			defer os.Unsetenv("PRODUCER_CLIENT_TYPE") // nolint: errcheck
 
 			producer, err := streamclient.NewProducer(tt.opts)
 			require.NoError(t, err)
@@ -61,9 +61,9 @@ func TestIntegrationNewProducer_Env(t *testing.T) {
 	}
 }
 
-func TestNewProducer_Pubsub(t *testing.T) {
-	_ = os.Setenv("STREAMCLIENT_PRODUCER", "pubsub")
-	defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
+func TestNewProducer_Unknown(t *testing.T) {
+	_ = os.Setenv("PRODUCER_CLIENT_TYPE", "pubsub")
+	defer os.Unsetenv("PRODUCER_CLIENT_TYPE") // nolint: errcheck
 
 	_, err := streamclient.NewProducer()
 	require.Error(t, err)
@@ -80,8 +80,8 @@ func TestNewProducer_Env_DryRun(t *testing.T) {
 }
 
 func TestNewProducer_Env_DryRun_Overridden(t *testing.T) {
-	_ = os.Setenv("STREAMCLIENT_PRODUCER", "inmem")
-	defer os.Unsetenv("STREAMCLIENT_PRODUCER") // nolint: errcheck
+	_ = os.Setenv("PRODUCER_CLIENT_TYPE", "inmem")
+	defer os.Unsetenv("PRODUCER_CLIENT_TYPE") // nolint: errcheck
 
 	_ = os.Setenv("DRY_RUN", "1")
 	defer os.Unsetenv("DRY_RUN") // nolint: errcheck
@@ -90,9 +90,4 @@ func TestNewProducer_Env_DryRun_Overridden(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "*inmemclient.producer", reflect.TypeOf(producer).String())
-}
-
-func TestNewProducer_Unknown(t *testing.T) {
-	_, err := streamclient.NewProducer()
-	assert.Error(t, err)
 }

--- a/streamclient/type.go
+++ b/streamclient/type.go
@@ -1,0 +1,31 @@
+package streamclient
+
+// Type represents the streamclient implementation type.
+type Type string
+
+const (
+	// Unknown represents an unknown streamclient implementation.
+	Unknown Type = "unknown"
+
+	// Inmem represents the in-memory streamclient implementation.
+	Inmem = "inmem"
+
+	// Kafka represents the Kafka streamclient implementation.
+	Kafka = "kafka"
+
+	// Standardstream represents the Standardstream streamclient implementation.
+	Standardstream = "standardstream"
+)
+
+func (t Type) String() string {
+	switch t {
+	case Inmem:
+		fallthrough
+	case Kafka:
+		fallthrough
+	case Standardstream:
+		return string(t)
+	}
+
+	return string(Unknown)
+}

--- a/streamconfig/consumer.go
+++ b/streamconfig/consumer.go
@@ -49,12 +49,9 @@ func NewConsumer(options ...Option) (Consumer, error) {
 	// provided via environment variables. If `AllowEnvironmentBasedConfiguration`
 	// is set to false, this step is skipped.
 	if config.AllowEnvironmentBasedConfiguration {
-		env := "consumer"
-		if config.Name != "" {
-			env = strings.Join([]string{config.Name, env}, "_")
-		}
+		var err error
 
-		err := envconfig.Process(env, config)
+		*config, err = config.FromEnv()
 		if err != nil {
 			return *config, err
 		}
@@ -97,4 +94,17 @@ func (c Consumer) WithOptions(opts ...Option) Consumer {
 	}
 
 	return *cc
+}
+
+// FromEnv populates the Consumer based on the environment variables set with
+// the prefix based on the consumer name.
+func (c Consumer) FromEnv() (Consumer, error) {
+	cc := &c
+
+	env := "consumer"
+	if c.Name != "" {
+		env = strings.Join([]string{c.Name, env}, "_")
+	}
+
+	return *cc, envconfig.Process(env, cc)
 }

--- a/streamconfig/consumer_test.go
+++ b/streamconfig/consumer_test.go
@@ -387,3 +387,28 @@ func TestNewConsumer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
 
 	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)
 }
+
+func TestConsumer_FromEnv(t *testing.T) {
+	_ = os.Setenv("CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	config := streamconfig.Consumer{Kafka: kafkaconfig.Consumer{}}
+
+	config, err := config.FromEnv()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}
+
+func TestConsumer_FromEnv_CustomName(t *testing.T) {
+	_ = os.Setenv("HELLO_CONSUMER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("HELLO_CONSUMER_KAFKA_BROKERS") // nolint: errcheck
+
+	config := streamconfig.Consumer{Kafka: kafkaconfig.Consumer{}}
+	config.Name = "hello"
+
+	config, err := config.FromEnv()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}

--- a/streamconfig/producer.go
+++ b/streamconfig/producer.go
@@ -49,12 +49,9 @@ func NewProducer(options ...Option) (Producer, error) {
 	// provided via environment variables. If `AllowEnvironmentBasedConfiguration`
 	// is set to false, this step is skipped.
 	if config.AllowEnvironmentBasedConfiguration {
-		env := "producer"
-		if config.Name != "" {
-			env = strings.Join([]string{config.Name, env}, "_")
-		}
+		var err error
 
-		err := envconfig.Process(env, config)
+		*config, err = config.FromEnv()
 		if err != nil {
 			return *config, err
 		}
@@ -97,4 +94,17 @@ func (p Producer) WithOptions(opts ...Option) Producer {
 	}
 
 	return *pp
+}
+
+// FromEnv populates the Producer based on the environment variables set with
+// the prefix based on the producer name.
+func (p Producer) FromEnv() (Producer, error) {
+	pp := &p
+
+	env := "producer"
+	if p.Name != "" {
+		env = strings.Join([]string{p.Name, env}, "_")
+	}
+
+	return *pp, envconfig.Process(env, pp)
 }

--- a/streamconfig/producer_test.go
+++ b/streamconfig/producer_test.go
@@ -424,3 +424,28 @@ func TestNewProducer_WithOptionsWithoutEnvironmentVariables(t *testing.T) {
 
 	assert.EqualValues(t, []string{"broker2"}, config.Kafka.Brokers)
 }
+
+func TestProducer_FromEnv(t *testing.T) {
+	_ = os.Setenv("PRODUCER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("PRODUCER_KAFKA_BROKERS") // nolint: errcheck
+
+	config := streamconfig.Producer{Kafka: kafkaconfig.Producer{}}
+
+	config, err := config.FromEnv()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}
+
+func TestProducer_FromEnv_CustomName(t *testing.T) {
+	_ = os.Setenv("HELLO_PRODUCER_KAFKA_BROKERS", "broker1")
+	defer os.Unsetenv("HELLO_PRODUCER_KAFKA_BROKERS") // nolint: errcheck
+
+	config := streamconfig.Producer{Kafka: kafkaconfig.Producer{}}
+	config.Name = "hello"
+
+	config, err := config.FromEnv()
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{"broker1"}, config.Kafka.Brokers)
+}


### PR DESCRIPTION
closes https://github.com/blendle/go-streamprocessor/issues/84

---

Before, you could only use one type of consumer and producer at the
same time. You did this by setting the `STREAMCLIENT_CONSUMER` and
`STREAMCLIENT_PRODUCER` environment variable.

If you had multiple consumers in your application, all of them would
become of the type you set with `STREAMCLIENT_CONSUMER`.

After this commit, we use the defined consumer (and producer) names to
determine the environment variables used to set their types.

For example, if your (pseudo) code looks like this:

    consumer, err := streamclient.NewConsumer()
    consumer, err := streamclient.NewConsumer(streamconfig.Name("hello"))
    producer, err := streamclient.NewProducer()

You can now set the type for these consumers and producer independently,
as follows:

    CONSUMER_CLIENT_TYPE=kafka
    HELLO_CONSUMER_CLIENT_TYPE=inmem
    PRODUCER_CLIENT_TYPE=standardstream