### PR TITLE
Make sure DRY_RUN is always honored for producers

### DIFF
--- a/streamclient/producer.go
+++ b/streamclient/producer.go
@@ -18,6 +18,10 @@ var ErrUnknownProducerClient = errors.New("unable to determine required producer
 // NewProducer returns a new streamclient producer, based on the context from
 // which this function is called.
 func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
+	if _, ok := os.LookupEnv("DRY_RUN"); ok {
+		return standardstreamclient.NewProducer(options...)
+	}
+
 	c, err := (&streamconfig.Producer{}).WithOptions(options...).FromEnv()
 	if err != nil {
 		return nil, err
@@ -32,9 +36,5 @@ func NewProducer(options ...streamconfig.Option) (stream.Producer, error) {
 		return kafkaclient.NewProducer(options...)
 	}
 
-	if os.Getenv("DRY_RUN") != "" {
-		return standardstreamclient.NewProducer(options...)
-	}
-
-	return nil, errors.New("unable to determine required producer streamclient")
+	return nil, ErrUnknownProducerClient
 }

--- a/streamclient/producer_test.go
+++ b/streamclient/producer_test.go
@@ -89,5 +89,5 @@ func TestNewProducer_Env_DryRun_Overridden(t *testing.T) {
 	producer, err := streamclient.NewProducer()
 	require.NoError(t, err)
 
-	assert.Equal(t, "*inmemclient.producer", reflect.TypeOf(producer).String())
+	assert.Equal(t, "*standardstreamclient.producer", reflect.TypeOf(producer).String())
 }


### PR DESCRIPTION
Before, `PRODUCER_CLIENT_TYPE=inmem` would override `DRY_RUN=1`. This
can cause dangerous situations where you expect adding `DRY_RUN` to
"just work", and no data to be produced to any production-like clients.

Now, `DRY_RUN` always overrides any other preferences, meaning all
producers in the application will produce their data to `stdout`.