### PR TITLE
Set standardstream's consumed messages timestamp to "now"

### DIFF
--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/blendle/go-streamprocessor/stream"
 	"github.com/blendle/go-streamprocessor/streamconfig"
@@ -161,7 +162,7 @@ func (c *consumer) consume() {
 		b := make([]byte, len(scanner.Bytes()))
 		copy(b, scanner.Bytes())
 
-		c.messages <- stream.Message{Value: b}
+		c.messages <- stream.Message{Value: b, Timestamp: time.Now()}
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -106,6 +106,17 @@ func TestConsumer_Messages(t *testing.T) {
 	assert.False(t, ok, "consumer did not close after last message")
 }
 
+func TestConsumer_Message_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	buffer := standardstreamclient.TestBuffer(t, "")
+	consumer, closer := standardstreamclient.TestConsumer(t, buffer)
+	defer closer()
+
+	msg := <-consumer.Messages()
+	assert.NotZero(t, msg.Timestamp)
+}
+
 func TestConsumer_Messages_Ordering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This makes the client compatible/usable in stream processors that act
on message timestamps.