### PR TITLE
Ignore transient errors when applicable

### DIFF
--- a/streamclient/kafkaclient/eventhandlers_test.go
+++ b/streamclient/kafkaclient/eventhandlers_test.go
@@ -1,0 +1,53 @@
+package kafkaclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func TestHandleError(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		err     kafka.ErrorCode
+		ignores []kafka.ErrorCode
+		out     string
+	}{
+		"no ignore":     {kafka.ErrBadMsg, []kafka.ErrorCode{}, "Local: Bad message format"},
+		"ignored":       {kafka.ErrBadMsg, []kafka.ErrorCode{kafka.ErrBadMsg}, ""},
+		"multi-ignored": {kafka.ErrBadMsg, []kafka.ErrorCode{kafka.ErrFail, kafka.ErrBadMsg}, ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			err := testErr{errors.New(tt.err.String()), tt.err}
+			ch := make(chan error, 100)
+			logger := zap.NewNop()
+
+			handleError(err, tt.ignores, ch, logger)
+
+			if tt.out == "" {
+				assert.Len(t, ch, 0)
+				return
+			}
+
+			got := <-ch
+
+			assert.Equal(t, got.Error(), "received error from event stream: "+tt.out)
+		})
+	}
+}
+
+type testErr struct {
+	err  error
+	code kafka.ErrorCode
+}
+
+func (e testErr) Error() string         { return e.err.Error() }
+func (e testErr) Code() kafka.ErrorCode { return e.code }

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -35,6 +35,7 @@ func TestConsumer(t *testing.T) {
 		GroupID:             "",
 		HeartbeatInterval:   time.Duration(0),
 		ID:                  "",
+		IgnoreErrors:        []kafka.ErrorCode{kafka.ErrBadMsg},
 		MaxInFlightRequests: 0,
 		OffsetInitial:       kafkaconfig.OffsetBeginning,
 		OffsetDefault:       &[]int64{5}[0],
@@ -50,10 +51,28 @@ func TestConsumerDefaults(t *testing.T) {
 	t.Parallel()
 
 	config := kafkaconfig.ConsumerDefaults
+	errs := []kafka.ErrorCode{
+		kafka.ErrTransport,
+		kafka.ErrAllBrokersDown,
+		kafka.ErrDestroy,
+		kafka.ErrFail,
+		kafka.ErrResolve,
+		kafka.ErrLeaderNotAvailable,
+		kafka.ErrNotLeaderForPartition,
+		kafka.ErrRequestTimedOut,
+		kafka.ErrBrokerNotAvailable,
+		kafka.ErrReplicaNotAvailable,
+		kafka.ErrNetworkException,
+		kafka.ErrGroupCoordinatorNotAvailable,
+		kafka.ErrNotCoordinatorForGroup,
+		kafka.ErrNotEnoughReplicas,
+		kafka.ErrNotEnoughReplicasAfterAppend,
+	}
 
 	assert.Equal(t, 5*time.Second, config.CommitInterval)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
+	assert.Equal(t, errs, config.IgnoreErrors)
 	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, kafkaconfig.OffsetBeginning, config.OffsetInitial)
 	assert.Equal(t, kafkaconfig.ProtocolPlaintext, config.SecurityProtocol)

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -31,6 +31,7 @@ func TestProducer(t *testing.T) {
 		Debug:                  kafkaconfig.Debug{All: true},
 		HeartbeatInterval:      time.Duration(0),
 		ID:                     "",
+		IgnoreErrors:           []kafka.ErrorCode{kafka.ErrBadMsg},
 		MaxDeliveryRetries:     0,
 		MaxInFlightRequests:    0,
 		MaxQueueBufferDuration: time.Duration(0),
@@ -49,11 +50,29 @@ func TestProducerDefaults(t *testing.T) {
 	t.Parallel()
 
 	config := kafkaconfig.ProducerDefaults
+	errs := []kafka.ErrorCode{
+		kafka.ErrTransport,
+		kafka.ErrAllBrokersDown,
+		kafka.ErrDestroy,
+		kafka.ErrFail,
+		kafka.ErrResolve,
+		kafka.ErrLeaderNotAvailable,
+		kafka.ErrNotLeaderForPartition,
+		kafka.ErrRequestTimedOut,
+		kafka.ErrBrokerNotAvailable,
+		kafka.ErrReplicaNotAvailable,
+		kafka.ErrNetworkException,
+		kafka.ErrGroupCoordinatorNotAvailable,
+		kafka.ErrNotCoordinatorForGroup,
+		kafka.ErrNotEnoughReplicas,
+		kafka.ErrNotEnoughReplicasAfterAppend,
+	}
 
 	assert.Equal(t, 10000, config.BatchMessageSize)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
 	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
+	assert.Equal(t, errs, config.IgnoreErrors)
 	assert.Equal(t, 2, config.MaxDeliveryRetries)
 	assert.Equal(t, 1000000, config.MaxInFlightRequests)
 	assert.Equal(t, 10*time.Millisecond, config.MaxQueueBufferDuration)

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
@@ -176,6 +177,16 @@ func KafkaGroupID(s string) Option {
 func KafkaGroupIDRandom() Option {
 	return optionFunc(func(c *Consumer, _ *Producer) {
 		c.Kafka.GroupID = fmt.Sprintf("processor-%s", uuid.Must(uuid.NewV4()))
+	})
+}
+
+// KafkaHandleTransientErrors passes _all_ errors to the errors channel,
+// including the ones that are considered "transient", and the consumer or
+// producer can resolve themselves eventually.
+func KafkaHandleTransientErrors() Option {
+	return optionFunc(func(c *Consumer, p *Producer) {
+		c.Kafka.IgnoreErrors = []kafka.ErrorCode{}
+		p.Kafka.IgnoreErrors = []kafka.ErrorCode{}
 	})
 }
 

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
 	"github.com/blendle/go-streamprocessor/streamstore/inmemstore"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -156,6 +157,16 @@ func TestOptions(t *testing.T) {
 			},
 			streamconfig.Producer{
 				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
+		"KafkaHandleTransientErrors": {
+			[]streamconfig.Option{streamconfig.KafkaHandleTransientErrors()},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{IgnoreErrors: []kafka.ErrorCode{}},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{IgnoreErrors: []kafka.ErrorCode{}},
 			},
 		},
 


### PR DESCRIPTION
Instead of exposing all errors that are returned by the Kafka brokers,
now only any non-transient errors are returned. This is in accordance
with the rdkafka documentation:

> These errors are normally just informational since the
> client will try its best to automatically recover (eventually)

If you want, you can still expose _all_ errors, by using the option:

    streamconfig.KafkaHandleTransientErrors()