### PR TITLE
 Add `Backlog` method signature to Consumer interface

### DIFF
--- a/stream/consumer.go
+++ b/stream/consumer.go
@@ -18,6 +18,12 @@ type Consumer interface {
 	// was _not_ processed, and should be delivered again in the future.
 	Nack(Message) error
 
+	// Backlog returns an integer, indicating the number of messages still to be
+	// consumed by the consumer. If the stream client implementation does not have
+	// the concept of stream persistence, or consumer identity, this will always
+	// return `0`. An error is returned if the backlog could not be determined.
+	Backlog() (int, error)
+
 	// Config returns the final configuration used by the consumer as an
 	// interface. To access the configuration, cast the interface to a
 	// `streamconfig.Consumer` struct.

--- a/stream/consumermock.go
+++ b/stream/consumermock.go
@@ -36,6 +36,11 @@ func (c *ConsumerMock) Close() error {
 	return nil
 }
 
+// Backlog implements the Consumer interface for ConsumerMock.
+func (c ConsumerMock) Backlog() (int, error) {
+	return 0, nil
+}
+
 // Config implements the Consumer interface for ConsumerMock.
 func (c ConsumerMock) Config() interface{} {
 	return c.Configuration

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -113,8 +113,8 @@ func TestConsumer_Backlog(t *testing.T) {
 	t.Parallel()
 
 	store := inmemstore.New()
-	store.Add(stream.Message{})
-	store.Add(stream.Message{})
+	_ = store.Add(stream.Message{})
+	_ = store.Add(stream.Message{})
 
 	// We pass the `InmemListen` option, which makes this consumer behave more
 	// like a regular consumer, continuously listening for new messages. Old
@@ -141,8 +141,8 @@ func TestConsumer_Backlog_ConsumeOnce(t *testing.T) {
 	t.Parallel()
 
 	store := inmemstore.New()
-	store.Add(stream.Message{})
-	store.Add(stream.Message{})
+	_ = store.Add(stream.Message{})
+	_ = store.Add(stream.Message{})
 
 	consumer, closer := inmemclient.TestConsumer(t, store)
 	defer closer()

--- a/streamclient/inmemclient/consumer_test.go
+++ b/streamclient/inmemclient/consumer_test.go
@@ -109,6 +109,56 @@ func TestConsumer_Messages_PerMessageMemoryAllocation(t *testing.T) {
 	}
 }
 
+func TestConsumer_Backlog(t *testing.T) {
+	t.Parallel()
+
+	store := inmemstore.New()
+	store.Add(stream.Message{})
+	store.Add(stream.Message{})
+
+	// We pass the `InmemListen` option, which makes this consumer behave more
+	// like a regular consumer, continuously listening for new messages. Old
+	// messages are discarded once read, which allows us to track the number of
+	// messages that still need to be consumed.
+	consumer, closer := inmemclient.TestConsumer(t, store, streamconfig.InmemListen())
+	defer closer()
+
+	time.Sleep(100 * time.Millisecond)
+
+	for _, want := range []int{2, 1, 0} {
+		got, err := consumer.Backlog()
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+
+		if want > 0 {
+			<-consumer.Messages()
+			time.Sleep(time.Millisecond) // wait for the message to be deleted
+		}
+	}
+}
+
+func TestConsumer_Backlog_ConsumeOnce(t *testing.T) {
+	t.Parallel()
+
+	store := inmemstore.New()
+	store.Add(stream.Message{})
+	store.Add(stream.Message{})
+
+	consumer, closer := inmemclient.TestConsumer(t, store)
+	defer closer()
+
+	for i := 0; i < 3; i++ {
+		got, err := consumer.Backlog()
+		require.NoError(t, err)
+
+		// When `ConsumeOnce` is enabled for the inmem consumer, there's no notion
+		// of an offset, so `0` is always returned.
+		assert.Equal(t, 0, got)
+
+		<-consumer.Messages()
+	}
+}
+
 func TestConsumer_Errors(t *testing.T) {
 	t.Parallel()
 

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -189,7 +189,8 @@ func TestIntegrationConsumer_Backlog(t *testing.T) {
 		assert.Equal(t, want, got)
 
 		if want > 0 {
-			consumer.Ack(<-consumer.Messages())
+			err := consumer.Ack(<-consumer.Messages())
+			require.NoError(t, err)
 		}
 
 		closer()

--- a/streamclient/kafkaclient/consumer_test.go
+++ b/streamclient/kafkaclient/consumer_test.go
@@ -174,6 +174,28 @@ func TestIntegrationConsumer_Messages_Ordering(t *testing.T) {
 	assert.Equal(t, messageCount, i)
 }
 
+func TestIntegrationConsumer_Backlog(t *testing.T) {
+	t.Parallel()
+	testutil.Integration(t)
+
+	topicAndGroup := testutil.Random(t)
+	kafkaclient.TestProduceMessages(t, topicAndGroup, "hello world", "hello universe!")
+
+	for _, want := range []int{2, 1, 0} {
+		consumer, closer := kafkaclient.TestConsumerWithAssignments(t, topicAndGroup)
+
+		got, err := consumer.Backlog()
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+
+		if want > 0 {
+			consumer.Ack(<-consumer.Messages())
+		}
+
+		closer()
+	}
+}
+
 func TestIntegrationConsumer_Errors(t *testing.T) {
 	t.Parallel()
 	testutil.Integration(t)
@@ -342,6 +364,22 @@ func TestIntegrationConsumer_OffsetTail(t *testing.T) {
 	closer()
 
 	assert.Equal(t, "good", string(message.Value))
+}
+
+func TestIntegrationConsumer_OffsetTail_Last(t *testing.T) {
+	t.Parallel()
+	testutil.Integration(t)
+
+	topicOrGroup := testutil.Random(t)
+
+	kafkaclient.TestProduceMessages(t, topicOrGroup, "hello", "hi", "good", "bye")
+
+	consumer, closer := kafkaclient.TestConsumer(t, topicOrGroup, streamconfig.KafkaOffsetTail(1))
+	defer closer()
+
+	message := streamclient.TestMessageFromConsumer(t, consumer)
+
+	assert.Equal(t, "bye", string(message.Value))
 }
 
 func TestIntegrationConsumer_OffsetHead(t *testing.T) {

--- a/streamclient/standardstreamclient/consumer.go
+++ b/streamclient/standardstreamclient/consumer.go
@@ -128,6 +128,12 @@ func (c *consumer) Close() (err error) {
 	return nil
 }
 
+// Backlog is a no-op implementation, since we currently don't support reading
+// the position of the consumer when consuming from a file descriptor.
+func (c *consumer) Backlog() (int, error) {
+	return 0, nil
+}
+
 // Config returns a read-only representation of the consumer configuration as an
 // interface. To access the underlying configuration struct, cast the interface
 // to `streamconfig.Consumer`.

--- a/streamclient/standardstreamclient/consumer_test.go
+++ b/streamclient/standardstreamclient/consumer_test.go
@@ -194,6 +194,25 @@ func TestConsumer_Messages_ScannerError(t *testing.T) {
 	assert.Contains(t, out, "unable to read message from stream: bufio.Scanner: token too long")
 }
 
+func TestConsumer_Backlog(t *testing.T) {
+	t.Parallel()
+
+	buffer := standardstreamclient.TestBuffer(t, "hello world", "hello universe!")
+	consumer, closer := standardstreamclient.TestConsumer(t, buffer)
+	defer closer()
+
+	for i := 0; i < 3; i++ {
+		got, err := consumer.Backlog()
+		require.NoError(t, err)
+
+		// The standardstreamclient does not support backlog reporting, `0` is
+		// always returned, no matter the position in the stream.
+		assert.Equal(t, 0, got)
+
+		<-consumer.Messages()
+	}
+}
+
 func TestConsumer_Errors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This allows for processors to determine their mode of operation, based on the messages still waiting to be consumed.

For example, if a processor continuously consumes messages, and periodically produces messages based on the previously consumed messages, it might be desired to have the producer only trigger if the backlog of the consumer is small enough. This allows for dynamically catching up with a larger backlog during peak-hours.

The method signature is straightforward:

```golang
Backlog() (int, error)
```

Stream client implementations that have no concept of message persistence or consumer identity, always return `0`. The error will be non-nil if any error occurred while fetching the required data.