### PR TITLE
Don't return nil error when the error channel closes

### DIFF
--- a/streamutil/error.go
+++ b/streamutil/error.go
@@ -21,7 +21,12 @@ func Errors(errs ...stream.ErrorCloser) <-chan error {
 
 		go func(c <-chan error) {
 			for {
-				errChan <- (<-c)
+				err, ok := <-c
+				if !ok {
+					return
+				}
+
+				errChan <- err
 			}
 		}(e.Errors())
 	}


### PR DESCRIPTION
Before, if you listened for any errors using streamutil.Errors, if the
errors channel was closed, a nil error was returned by the function.

This usually happened if you close a consumer or producer, but are still
listening for errors. Since the consumer or producer will close its
errors channel, you would receive a nil value.

This was error prone, as you had to explicitly check for non-nil errors
before acting on the error.

Now, an explicit nil error is delivered as expected, but a nil error due
to channel closure is ignored.