### PR TITLE
Deprecate test logger in favour of new Zap test logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-- "1.10.1"
+- "1.11.1"
 
 services:
 - docker

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -83,7 +83,9 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
+    "internal/ztest",
     "zapcore",
+    "zaptest",
   ]
   pruneopts = ""
   revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
@@ -101,6 +103,7 @@
     "github.com/stretchr/testify/require",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
+    "go.uber.org/zap/zaptest",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,14 +6,14 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+os=$(uname -s | awk '{print tolower($0)}')
+
 if [ -n "$CI" ] || ! command -v dep >/dev/null 2>&1; then
-  os=$(uname -s | awk '{print tolower($0)}')
   curl -L "https://github.com/golang/dep/releases/download/v0.5.0/dep-$os-amd64" >"$GOPATH/bin/dep"
   chmod +x "$GOPATH/bin/dep"
 fi
 
 if [ -n "$CI" ] || ! command -v shellcheck >/dev/null 2>&1; then
-  os=$(uname -s | awk '{print tolower($0)}')
   if [ "$os" = "darwin" ]; then
     echo >&2 "You need to install shellcheck before continuing."
   fi
@@ -28,11 +28,21 @@ if [ -n "$CI" ] || ! command -v shellcheck >/dev/null 2>&1; then
 fi
 
 if [ -n "$CI" ] || ! command -v shfmt >/dev/null 2>&1; then
-  os=$(uname -s | awk '{print tolower($0)}')
   curl -L "https://github.com/mvdan/sh/releases/download/v2.5.0/shfmt_v2.5.0_${os}_amd64" >"$GOPATH/bin/shfmt"
 
   chmod +x "$GOPATH/bin/shfmt"
 fi
 
-go get -u github.com/alecthomas/gometalinter
-gometalinter --install
+if [ -n "$CI" ] || ! command -v gometalinter >/dev/null 2>&1; then
+  if [ "$os" = "darwin" ]; then
+    echo >&2 "You need to install gometalinter before continuing."
+  fi
+
+  tmp=$(mktemp -d)
+  curl -Ls "https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-$os-amd64.tar.gz" |
+    tar xzf - --strip 1 -C "$tmp"
+
+  mkdir -p "$GOPATH/bin"
+  cp "${tmp}/"* "$GOPATH/bin/"
+  chmod +x "$GOPATH/bin/"*
+fi

--- a/streamclient/kafkaclient/eventhandlers_test.go
+++ b/streamclient/kafkaclient/eventhandlers_test.go
@@ -3,11 +3,10 @@ package kafkaclient
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestHandleError(t *testing.T) {
@@ -28,7 +27,7 @@ func TestHandleError(t *testing.T) {
 
 			err := testErr{errors.New(tt.err.String()), tt.err}
 			ch := make(chan error, 100)
-			logger := zap.NewNop()
+			logger := zaptest.NewLogger(t)
 
 			handleError(err, tt.ignores, ch, logger)
 

--- a/streamclient/kafkaclient/producer_test.go
+++ b/streamclient/kafkaclient/producer_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestIntegrationNewProducer(t *testing.T) {
@@ -234,8 +233,6 @@ func BenchmarkIntegrationProducer_Messages(b *testing.B) {
 	testutil.Integration(b)
 
 	topic := testutil.Random(b)
-	logger, err := zap.NewDevelopment()
-	require.NoError(b, err, logger)
 
 	// We use the default (production-like) config in this benchmark, to simulate
 	// real-world usage as best as possible.

--- a/streamconfig/consumer_test.go
+++ b/streamconfig/consumer_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
-	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestConsumer(t *testing.T) {
@@ -26,9 +27,9 @@ func TestConsumer(t *testing.T) {
 		Standardstream: standardstreamconfig.Consumer{},
 
 		Global: streamconfig.Global{
-			Logger:          testutil.Logger(t),
-			HandleInterrupt: false,
-			Name:            "",
+			Logger:                             zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)),
+			HandleInterrupt:                    false,
+			Name:                               "",
 			AllowEnvironmentBasedConfiguration: false,
 		},
 	}

--- a/streamconfig/global.go
+++ b/streamconfig/global.go
@@ -41,8 +41,8 @@ type Global struct {
 
 // GlobalDefaults provide a default of global preferences.
 var GlobalDefaults = Global{
-	HandleErrors:    true,
-	HandleInterrupt: true,
-	Name:            "",
+	HandleErrors:                       true,
+	HandleInterrupt:                    true,
+	Name:                               "",
 	AllowEnvironmentBasedConfiguration: true,
 }

--- a/streamconfig/producer_test.go
+++ b/streamconfig/producer_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/pubsubconfig"
 	"github.com/blendle/go-streamprocessor/streamconfig/standardstreamconfig"
-	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestProducer(t *testing.T) {
@@ -26,9 +27,9 @@ func TestProducer(t *testing.T) {
 		Standardstream: standardstreamconfig.Producer{},
 
 		Global: streamconfig.Global{
-			Logger:          testutil.Logger(t),
-			HandleInterrupt: false,
-			Name:            "",
+			Logger:                             zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)),
+			HandleInterrupt:                    false,
+			Name:                               "",
 			AllowEnvironmentBasedConfiguration: false,
 		},
 	}

--- a/streamconfig/testing_test.go
+++ b/streamconfig/testing_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/blendle/go-streamprocessor/streamconfig/kafkaconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestTestNewConsumer(t *testing.T) {
@@ -29,9 +29,7 @@ func TestTestNewConsumer_WithoutDefaults(t *testing.T) {
 }
 
 func TestTestNewConsumer_WithOptions(t *testing.T) {
-	logger, err := zap.NewDevelopment()
-	require.NoError(t, err)
-
+	logger := zaptest.NewLogger(t)
 	c1 := streamconfig.Consumer{Global: streamconfig.Global{Logger: logger}}
 	c2 := streamconfig.TestNewConsumer(t, false, streamconfig.Logger(logger))
 
@@ -81,9 +79,7 @@ func TestTestNewProducer_WithoutDefaults(t *testing.T) {
 }
 
 func TestTestNewProducer_WithOptions(t *testing.T) {
-	logger, err := zap.NewDevelopment()
-	require.NoError(t, err)
-
+	logger := zaptest.NewLogger(t)
 	p1 := streamconfig.Producer{Global: streamconfig.Global{Logger: logger}}
 	p2 := streamconfig.TestNewProducer(t, false, streamconfig.Logger(logger))
 

--- a/streamutil/testutil/testing.go
+++ b/streamutil/testutil/testing.go
@@ -99,12 +99,19 @@ func Integration(tb testing.TB) {
 
 // Logger returns a Zap logger instance to use during testing. It returns logs
 // in a user-friendly format, reporting anything above warn level.
+//
+// DEPRECATED: this is now supported by Zap itself, since version `1.9.0`.
+//
+//             See: https://github.com/uber-go/zap/pull/518
+//
 func Logger(tb testing.TB) *zap.Logger {
 	cfg := zap.NewDevelopmentConfig()
 	cfg.Level.SetLevel(zap.ErrorLevel)
 
 	log, err := cfg.Build()
 	require.NoError(tb, err)
+
+	log.Error("testing.Logger is deprecated, please use zaptest.NewLogger")
 
 	return log
 }

--- a/streamutil/testutil/testing_test.go
+++ b/streamutil/testutil/testing_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/blendle/go-streamprocessor/streamutil/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestIntegration_Test(t *testing.T) {
@@ -33,7 +35,8 @@ func TestExec(t *testing.T) {
 }
 
 func TestLogger(t *testing.T) {
-	assert.Equal(t, "*zap.Logger", reflect.TypeOf(testutil.Logger(t)).String())
+	assert.Equal(t, "*zap.Logger",
+		reflect.TypeOf(zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel))).String())
 }
 
 func TestVerbose_TEST_DEBUG(t *testing.T) {


### PR DESCRIPTION
See: https://github.com/uber-go/zap/pull/518