### PR TITLE
Upgrade librdkafka to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 env:
   global:
-  - LIBRDKAFKA_VERSION=v0.11.6
+  - LIBRDKAFKA_VERSION=v1.0.0
   - PKG_CONFIG_PATH="$GOPATH/src/github.com/blendle/go-streamprocessor/tmp-build/$LIBRDKAFKA_VERSION/lib/pkgconfig"
   - LD_LIBRARY_PATH="$GOPATH/src/github.com/blendle/go-streamprocessor/tmp-build/$LIBRDKAFKA_VERSION/lib"
   - DYLD_LIBRARY_PATH="$GOPATH/src/github.com/blendle/go-streamprocessor/tmp-build/$LIBRDKAFKA_VERSION/lib"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:d091b4c15112c3a24dc5b1b03290a0076fececdc9944c06cb4b8ff039f80d00a"
+  digest = "1:aaaf33c312d07806c150cabe356f2038a36f40d78d587fca2da1690b6727bde8"
   name = "github.com/confluentinc/confluent-kafka-go"
   packages = ["kafka"]
   pruneopts = ""
-  revision = "460e8e43b282a1a68219df600ef63442b81faf5f"
-  version = "v0.11.6"
+  revision = "ecccefd9ca31c656bd33471dc0d9293fcf3de99b"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
@@ -25,12 +25,12 @@
   revision = "dd1402a4d99de9ac2f396cd6fcb957bc2c695ec1"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = ""
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -48,23 +48,23 @@
   revision = "8ccf5352a842c034b1a69f28c863aff9b1cdb116"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
   ]
   pruneopts = ""
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
-  digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
+  digest = "1:e6ff7840319b6fda979a918a8801005ec2049abca62af19211d96971d8ec3327"
   name = "go.uber.org/atomic"
   packages = ["."]
   pruneopts = ""
-  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
-  version = "v1.3.2"
+  revision = "df976f2515e274675050de7b3f42545de80594fd"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:22c7effcb4da0eacb2bb1940ee173fac010e9ef3c691f5de4b524d538bd980f5"
@@ -75,7 +75,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:246f378f80fba6fcf0f191c486b6613265abd2bc0f2fa55a36b928c67352021e"
+  digest = "1:984e93aca9088b440b894df41f2043b6a3db8f9cf30767032770bfc4796993b0"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -88,8 +88,8 @@
     "zaptest",
   ]
   pruneopts = ""
-  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
-  version = "v1.9.1"
+  revision = "27376062155ad36be76b0f12cf1572a221d3a48c"
+  version = "v1.10.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/confluentinc/confluent-kafka-go"
-  version = "v0.11.6"
+  version = "v1.0"
 
 [[constraint]]
   name = "github.com/kelseyhightower/envconfig"

--- a/streamclient/kafkaclient/producer.go
+++ b/streamclient/kafkaclient/producer.go
@@ -118,7 +118,7 @@ func (p *producer) Close() (err error) {
 		// before we abort the flush operation. If any messages are still not
 		// delivered after the timeout expires, we return an error, indicating that
 		// something went wrong.
-		i := p.kafka.Flush(5000)
+		i := p.kafka.Flush(10000)
 		if i > 0 {
 			err = fmt.Errorf("failed to flush all messages, %d left", i)
 			return

--- a/streamclient/kafkaclient/testing.go
+++ b/streamclient/kafkaclient/testing.go
@@ -147,7 +147,7 @@ func TestProduceMessages(tb testing.TB, topic string, values ...interface{}) {
 
 		select {
 		case <-producer.Events():
-		case <-time.After(testutil.MultipliedDuration(tb, 5*time.Second)):
+		case <-time.After(testutil.MultipliedDuration(tb, 10*time.Second)):
 			require.Fail(tb, "Timeout while waiting for message to be delivered.")
 		}
 	}
@@ -235,7 +235,7 @@ func testKafkaProducer(tb testing.TB) (*kafka.Producer, func()) {
 	require.NoError(tb, err)
 
 	closer := func() {
-		i := producer.Flush(testutil.MultipliedInt(tb, 1000))
+		i := producer.Flush(testutil.MultipliedInt(tb, 4000))
 		require.Zero(tb, i, "expected all messages to be flushed")
 
 		producer.Close()

--- a/streamclient/kafkaclient/testing_test.go
+++ b/streamclient/kafkaclient/testing_test.go
@@ -76,8 +76,7 @@ func TestIntegrationTestMessageFromTopic(t *testing.T) {
 	topicAndGroup := testutil.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
-		"produce.offset.report": false,
+		"metadata.broker.list": kafkaconfig.TestBrokerAddress,
 	}
 
 	producer, err := kafka.NewProducer(config)
@@ -103,8 +102,7 @@ func TestIntegrationTestMessagesFromTopic(t *testing.T) {
 	topicAndGroup := testutil.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
-		"produce.offset.report": false,
+		"metadata.broker.list": kafkaconfig.TestBrokerAddress,
 	}
 	producer, err := kafka.NewProducer(config)
 	require.NoError(t, err)
@@ -209,9 +207,8 @@ func TestIntegrationTestOffsets(t *testing.T) {
 	topicAndGroup := testutil.Random(t)
 
 	config := &kafka.ConfigMap{
-		"metadata.broker.list":  kafkaconfig.TestBrokerAddress,
-		"produce.offset.report": false,
-		"message.timeout.ms":    60000,
+		"metadata.broker.list": kafkaconfig.TestBrokerAddress,
+		"message.timeout.ms":   60000,
 	}
 	producer, err := kafka.NewProducer(config)
 	require.NoError(t, err)

--- a/streamclient/testing.go
+++ b/streamclient/testing.go
@@ -20,7 +20,7 @@ func TestMessageFromConsumer(tb testing.TB, consumer stream.Consumer) stream.Mes
 		require.NotNil(tb, m)
 
 		return m
-	case <-time.After(testutil.MultipliedDuration(tb, 3*time.Second)):
+	case <-time.After(testutil.MultipliedDuration(tb, 10*time.Second)):
 		require.Fail(tb, "Timeout while waiting for message to be returned.")
 	}
 

--- a/streamconfig/consumer_test.go
+++ b/streamconfig/consumer_test.go
@@ -127,6 +127,13 @@ func TestConsumerEnvironmentVariables(t *testing.T) {
 			},
 		},
 
+		"Kafka.MaxPollInterval": {
+			map[string]string{"CONSUMER_KAFKA_MAX_POLL_INTERVAL": "300s"},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{MaxPollInterval: 300 * time.Second},
+			},
+		},
+
 		"Kafka.OffsetDefault (positive)": {
 			map[string]string{"CONSUMER_KAFKA_OFFSET_DEFAULT": "10"},
 			streamconfig.Consumer{

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -206,6 +206,7 @@ var ConsumerDefaults = Consumer{
 		kafka.ErrNotEnoughReplicas,
 		kafka.ErrNotEnoughReplicasAfterAppend,
 		kafka.ErrUnknownMemberID,
+		kafka.ErrMaxPollExceeded,
 	},
 	MaxInFlightRequests: 1000000,
 	OffsetInitial:       OffsetBeginning,

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -60,6 +60,21 @@ type Consumer struct {
 	// consumer fetch request per broker to one.
 	MaxInFlightRequests int `kafka:"max.in.flight.requests.per.connection,omitempty" split_words:"true"` // nolint: lll
 
+	// MaxPollInterval determines the maximum allowed time between calls to
+	// consume messages. If this interval is exceeded the consumer is
+	// considered failed and the group will rebalance in order to reassign the
+	// partitions to another consumer group member.
+	//
+	// Warning: Offset commits may be not possible at this point.
+	//
+	// Note: It is recommended to set `EnableAutoOffsetStore` to `false` for
+	// long-time processing applications and then explicitly store offsets
+	// (using offsets_store()) after message processing, to make sure offsets
+	// are not auto-committed prior to processing has finished.
+	//
+	// The interval is checked two times per second.
+	MaxPollInterval time.Duration `kafka:"max.poll.interval.ms,omitempty" split_words:"true"`
+
 	// OffsetDefault sets an offset starting point from which to consume messages.
 	// If this value is set to zero (0), the value is ignored, and the
 	// `OffsetInitial` is used instead (see its description for more details). If

--- a/streamconfig/kafkaconfig/consumer.go
+++ b/streamconfig/kafkaconfig/consumer.go
@@ -177,13 +177,6 @@ type staticConsumer struct {
 	//
 	// See: https://git.io/vp5eH
 	QueuedMinMessages int `kafka:"queued.min.messages"`
-
-	// SocketBlockingMax dictates the maximum time a broker socket operation may
-	// block. A lower value improves responsiveness at the expense of slightly
-	// higher CPU usage.
-	//
-	// See: https://git.io/vp5eH
-	SocketBlockingMax time.Duration `kafka:"socket.blocking.max.ms"`
 }
 
 // ConsumerDefaults holds the default values for Consumer.
@@ -223,13 +216,11 @@ var ConsumerDefaults = Consumer{
 }
 
 var staticConsumerDefaults = &staticConsumer{
-	EnableEventsChannel:     true,
-	EnableEventPartitionEOF: false,
-	EnableAutoCommit:        true,
-	EnableAutoOffsetStore:   false,
-	EnableEventRebalance:    true,
-	QueuedMinMessages:       500000,
-	SocketBlockingMax:       50 * time.Millisecond,
+	EnableEventsChannel:   true,
+	EnableAutoCommit:      true,
+	EnableAutoOffsetStore: false,
+	EnableEventRebalance:  true,
+	QueuedMinMessages:     500000,
 }
 
 // ConfigMap converts the current configuration into a format known to the

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -36,6 +36,7 @@ func TestConsumer(t *testing.T) {
 		ID:                  "",
 		IgnoreErrors:        []kafka.ErrorCode{kafka.ErrBadMsg},
 		MaxInFlightRequests: 0,
+		MaxPollInterval:     time.Duration(0),
 		OffsetInitial:       kafkaconfig.OffsetBeginning,
 		OffsetDefault:       &[]int64{5}[0],
 		SecurityProtocol:    kafkaconfig.ProtocolPlaintext,

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -67,6 +67,7 @@ func TestConsumerDefaults(t *testing.T) {
 		kafka.ErrNotEnoughReplicas,
 		kafka.ErrNotEnoughReplicasAfterAppend,
 		kafka.ErrUnknownMemberID,
+		kafka.ErrMaxPollExceeded,
 	}
 
 	assert.Equal(t, 5*time.Second, config.CommitInterval)

--- a/streamconfig/kafkaconfig/consumer_test.go
+++ b/streamconfig/kafkaconfig/consumer_test.go
@@ -18,7 +18,6 @@ var consumerDefaults = map[string]interface{}{
 	"enable.auto.offset.store":        false,
 	"go.application.rebalance.enable": true,
 	"queued.min.messages":             500000,
-	"socket.blocking.max.ms":          50,
 }
 
 var consumerOmitempties = []string{

--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -91,7 +91,7 @@ type Producer struct {
 	// AckAll: broker will block until message is committed by all in sync
 	// replicas (ISRs).
 	//
-	// Defaults to `AckLeader`.
+	// Defaults to `AckAll`.
 	RequiredAcks Ack `kafka:"{topic}.request.required.acks" split_words:"true"`
 
 	// RetryBackoff sets the backoff time before retrying a protocol request.

--- a/streamconfig/option.go
+++ b/streamconfig/option.go
@@ -224,6 +224,15 @@ func KafkaMaxInFlightRequests(i int) Option {
 	})
 }
 
+// KafkaMaxPollInterval sets the maximum allowed poll timeout.
+//
+// This option has no effect when applied to a producer.
+func KafkaMaxPollInterval(d time.Duration) Option {
+	return optionFunc(func(c *Consumer, _ *Producer) {
+		c.Kafka.MaxPollInterval = d
+	})
+}
+
 // KafkaMaxQueueBufferDuration sets the MaxQueueBufferDuration.
 //
 // This option has no effect when applied to a consumer.

--- a/streamconfig/option_test.go
+++ b/streamconfig/option_test.go
@@ -210,6 +210,16 @@ func TestOptions(t *testing.T) {
 			},
 		},
 
+		"KafkaMaxPollInterval": {
+			[]streamconfig.Option{streamconfig.KafkaMaxPollInterval(1 * time.Second)},
+			streamconfig.Consumer{
+				Kafka: kafkaconfig.Consumer{MaxPollInterval: 1 * time.Second},
+			},
+			streamconfig.Producer{
+				Kafka: kafkaconfig.Producer{},
+			},
+		},
+
 		"KafkaMaxQueueBufferDuration": {
 			[]streamconfig.Option{streamconfig.KafkaMaxQueueBufferDuration(1 * time.Second)},
 			streamconfig.Consumer{


### PR DESCRIPTION
A couple of notes:

- we kept the current Golang version dependency for now
- we didn't migrate to `go mod` yet, there's no need for now
- we had to increase some test timeouts due to more random failures, either because Travis hardware changed since we worked on this project, or because the 1.0.0 upgrade made it a bit harder to do the kind of testing we're doing (fast creation of topics, inserting and fetching data, and then deleting the topics again).
- we used the upgrade guide of both [librdkafka](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0) and [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go/releases/tag/v1.0.0)
- we didn't add the new idempotent producer functionality yet, it would help us a lot, but that'll have to wait for another time.

I'll rebase this branch, merge it and cut a new release once everything is approved.