### PR TITLE
better default for MaxQueueBufferDuration

### DIFF
--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -71,7 +71,8 @@ type Producer struct {
 	// queue to accumulate before constructing message batches (MessageSets) to
 	// transmit to brokers. A higher value allows larger and more effective (less
 	// overhead, improved compression) batches of messages to accumulate at the
-	// expense of increased message delivery latency. Defaults to 10 ms.
+    // expense of increased message delivery latency. Defaults to 500 ms to
+    // strike a balance between latency and throughput.
 	MaxQueueBufferDuration time.Duration `kafka:"queue.buffering.max.ms,omitempty" split_words:"true"`
 
 	// MaxQueueSizeKBytes is the maximum total message size sum allowed on the
@@ -171,7 +172,7 @@ var ProducerDefaults = Producer{
 	},
 	MaxDeliveryRetries:     5,
 	MaxInFlightRequests:    1000000,
-	MaxQueueBufferDuration: 10 * time.Millisecond,
+	MaxQueueBufferDuration: 500 * time.Millisecond,
 	MaxQueueSizeKBytes:     2097151,
 	MaxQueueSizeMessages:   1000000,
 	RequiredAcks:           AckAll,

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -78,7 +78,7 @@ func TestProducerDefaults(t *testing.T) {
 	assert.Equal(t, errs, config.IgnoreErrors)
 	assert.Equal(t, 5, config.MaxDeliveryRetries)
 	assert.Equal(t, 1000000, config.MaxInFlightRequests)
-	assert.Equal(t, 10*time.Millisecond, config.MaxQueueBufferDuration)
+	assert.Equal(t, 500*time.Millisecond, config.MaxQueueBufferDuration)
 	assert.Equal(t, 2097151, config.MaxQueueSizeKBytes)
 	assert.Equal(t, 1000000, config.MaxQueueSizeMessages)
 	assert.EqualValues(t, kafkaconfig.AckAll, config.RequiredAcks)


### PR DESCRIPTION
1ms is the librdkafka default, but it's tuned for lowest possible latency. After 1000ms, the increase in throughput is (according to the documentation) negligible, so let's set this to 500ms for a nice middle ground, and individual applications can tweak as needed.