### PR TITLE
better default for CompressionCodec

### DIFF
--- a/streamconfig/kafkaconfig/producer.go
+++ b/streamconfig/kafkaconfig/producer.go
@@ -26,8 +26,7 @@ type Producer struct {
 
 	// CompressionCodec sets the compression codec to use for compressing message
 	// sets. This is the default value for all topics, may be overridden by the
-	// topic configuration property compression.codec. Set tot `Snappy` by
-	// default.
+    // topic configuration property compression.codec. Set to `LZ4` by default.
 	CompressionCodec Compression `kafka:"compression.codec,omitempty" split_words:"true"`
 
 	// Debug allows tweaking of the default debug values.
@@ -143,7 +142,7 @@ type staticProducer struct {
 // ProducerDefaults holds the default values for Producer.
 var ProducerDefaults = Producer{
 	BatchMessageSize:  10000,
-	CompressionCodec:  CompressionSnappy,
+	CompressionCodec:  CompressionLZ4,
 	Debug:             Debug{},
 	HeartbeatInterval: 1 * time.Second,
 	IgnoreErrors: []kafka.ErrorCode{

--- a/streamconfig/kafkaconfig/producer_test.go
+++ b/streamconfig/kafkaconfig/producer_test.go
@@ -73,7 +73,7 @@ func TestProducerDefaults(t *testing.T) {
 
 	assert.Equal(t, 10000, config.BatchMessageSize)
 	assert.Equal(t, kafkaconfig.Debug{}, config.Debug)
-	assert.Equal(t, kafkaconfig.CompressionSnappy, config.CompressionCodec)
+	assert.Equal(t, kafkaconfig.CompressionLZ4, config.CompressionCodec)
 	assert.Equal(t, 1*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, errs, config.IgnoreErrors)
 	assert.Equal(t, 5, config.MaxDeliveryRetries)


### PR DESCRIPTION
It's faster than Snappy, in most circumstances.